### PR TITLE
Bring mutability back

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 major = 0
-minor = 15
+minor = 16
 patch = 0

--- a/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
+++ b/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
@@ -1,6 +1,5 @@
 package me.zeroeightsix.fiber;
 
-import me.zeroeightsix.fiber.builder.ConfigTreeBuilder;
 import me.zeroeightsix.fiber.exception.DuplicateChildException;
 import me.zeroeightsix.fiber.exception.RuntimeFiberException;
 import me.zeroeightsix.fiber.tree.ConfigBranch;
@@ -44,13 +43,13 @@ public class NodeOperations {
      * @param value The leaf node to be inherited
      * @param to    The mutated {@link ConfigBranch} that will inherit <code>value</code>
      */
-    public static void moveNode(ConfigNode value, ConfigTreeBuilder to) {
+    public static void moveNode(ConfigNode value, ConfigTree to) {
         try {
             ConfigBranch parent = value.getParent();
             if (parent != null) {
                 parent.getItems().remove(value);
             }
-            to.withChild(value, true);
+            to.getItems().add(value, true);
         } catch (DuplicateChildException e) {
             throw new RuntimeFiberException("Failed to merge value", e);
         }

--- a/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
+++ b/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
@@ -45,10 +45,7 @@ public class NodeOperations {
      */
     public static void moveNode(ConfigNode value, ConfigTree to) {
         try {
-            ConfigBranch parent = value.getParent();
-            if (parent != null) {
-                parent.getItems().remove(value);
-            }
+            value.detach();
             to.getItems().add(value, true);
         } catch (DuplicateChildException e) {
             throw new RuntimeFiberException("Failed to merge value", e);

--- a/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
+++ b/src/main/java/me/zeroeightsix/fiber/NodeOperations.java
@@ -1,47 +1,62 @@
 package me.zeroeightsix.fiber;
 
 import me.zeroeightsix.fiber.builder.ConfigTreeBuilder;
-import me.zeroeightsix.fiber.exception.FiberException;
+import me.zeroeightsix.fiber.exception.DuplicateChildException;
 import me.zeroeightsix.fiber.exception.RuntimeFiberException;
-import me.zeroeightsix.fiber.tree.*;
+import me.zeroeightsix.fiber.tree.ConfigBranch;
+import me.zeroeightsix.fiber.tree.ConfigNode;
+import me.zeroeightsix.fiber.tree.ConfigTree;
+import me.zeroeightsix.fiber.tree.Property;
+
+import java.util.Iterator;
 
 public class NodeOperations {
 
     /**
-     * Merges two {@code ConfigNode} objects.
+     * Merges two {@code ConfigTree}s.
      *
-     * <p> The first parameter {@code from} remains unchanged, but {@code to} will be mutated and receive all of {@code from}'s children.
+     * <p> The first parameter {@code from} will be stripped of its children,
+     * and {@code to} will receive all of {@code from}'s children.
      *
      * <p> If both nodes have one or more children with the same name, the child from {@code from} takes priority.
      *
      * @param from  The {@code ConfigNode} that will be read from, but not mutated.
      * @param to    The mutated {@link ConfigBranch} that will inherit <code>from</code>'s values and nodes.
      */
-    public static void mergeTo(ConfigTree from, ConfigTreeBuilder to) {
+    public static void moveChildren(ConfigTree from, ConfigTree to) {
         try {
-            for (ConfigNode item : from.getItems()) {
-                to.withChild(item, true);
+            for (Iterator<ConfigNode> it = from.getItems().iterator(); it.hasNext(); ) {
+                ConfigNode item = it.next();
+                it.remove();
+                to.getItems().add(item, true);
             }
-        } catch (FiberException e) {
+        } catch (DuplicateChildException e) {
             throw new RuntimeFiberException("Failed to merge nodes", e);
         }
     }
 
     /**
-     * Merges a leaf node ({@code ConfigLeaf}) into a {@code ConfigNode}.
+     * Moves a node ({@code ConfigNode}) to a new parent {@code ConfigTree}.
+     *
+     * <p> If the moved node has an existing parent, it will be detached.
+     * If the new parent has an existing node with the same name, it will be overwritten.
      *
      * @param value The leaf node to be inherited
      * @param to    The mutated {@link ConfigBranch} that will inherit <code>value</code>
      */
-    public static void mergeTo(ConfigLeaf<?> value, ConfigTreeBuilder to) {
+    public static void moveNode(ConfigNode value, ConfigTreeBuilder to) {
         try {
+            ConfigBranch parent = value.getParent();
+            if (parent != null) {
+                parent.getItems().remove(value);
+            }
             to.withChild(value, true);
-        } catch (FiberException e) {
+        } catch (DuplicateChildException e) {
             throw new RuntimeFiberException("Failed to merge value", e);
         }
     }
 
-    public static <T> void mergeTo(Property<T> from, Property<T> to) {
+    public static <T> void copyValue(Property<T> from, Property<T> to) {
         to.setValue(from.getValue());
     }
 }

--- a/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
+++ b/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
@@ -129,7 +129,7 @@ public class AnnotatedSettings {
             convention = new NoNamingConvention();
         }
 
-        NodeOperations.mergeTo(constructNode(pojoClass, pojo, onlyAnnotated, convention), mergeTo);
+        NodeOperations.moveChildren(constructNode(pojoClass, pojo, onlyAnnotated, convention), mergeTo);
     }
 
     private <P> ConfigTreeBuilder constructNode(Class<P> pojoClass, P pojo, boolean onlyAnnotated, SettingNamingConvention convention) throws FiberException {

--- a/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
+++ b/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
@@ -113,7 +113,7 @@ public class AnnotatedSettings {
         return builder.build();
     }
 
-    public <P> void applyToNode(ConfigTreeBuilder mergeTo, P pojo) throws FiberException {
+    public <P> void applyToNode(ConfigTree mergeTo, P pojo) throws FiberException {
         @SuppressWarnings("unchecked")
         Class<P> pojoClass = (Class<P>) pojo.getClass();
 

--- a/src/main/java/me/zeroeightsix/fiber/builder/ConfigLeafBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/ConfigLeafBuilder.java
@@ -3,7 +3,6 @@ package me.zeroeightsix.fiber.builder;
 import me.zeroeightsix.fiber.builder.constraint.ConstraintsBuilder;
 import me.zeroeightsix.fiber.constraint.Constraint;
 import me.zeroeightsix.fiber.constraint.FinalConstraint;
-import me.zeroeightsix.fiber.exception.FiberException;
 import me.zeroeightsix.fiber.exception.RuntimeFiberException;
 import me.zeroeightsix.fiber.tree.ConfigLeaf;
 import me.zeroeightsix.fiber.tree.ConfigLeafImpl;
@@ -190,8 +189,8 @@ public class ConfigLeafBuilder<T> {
             // Though, we don't really want to throw an exception on this method because no developer likes try-catching every setting they build.
             // Let's tread with caution.
             try {
-                parentNode.withChild(built);
-            } catch (FiberException e) {
+                parentNode.getItems().add(built);
+            } catch (RuntimeFiberException e) {
                 throw new RuntimeFiberException("Failed to register leaf to node", e);
             }
         }

--- a/src/main/java/me/zeroeightsix/fiber/builder/ConfigTreeBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/ConfigTreeBuilder.java
@@ -44,7 +44,7 @@ import java.util.function.Consumer;
 public class ConfigTreeBuilder implements ConfigTree {
     private final NodeCollection items = new IndexedNodeCollection(null);
     @Nullable
-    protected ConfigTreeBuilder parent;
+    protected ConfigTree parent;
     @Nullable
     protected String name;
     @Nullable
@@ -58,9 +58,9 @@ public class ConfigTreeBuilder implements ConfigTree {
      * @param parent the initial parent
      * @param name   the initial name
      * @see ConfigTree#builder()
-     * @see ConfigBranch#builder(ConfigTreeBuilder, String)
+     * @see ConfigBranch#builder(ConfigTree, String)
      */
-    public ConfigTreeBuilder(@Nullable ConfigTreeBuilder parent, @Nullable String name) {
+    public ConfigTreeBuilder(@Nullable ConfigTree parent, @Nullable String name) {
         if (parent != null && name == null) throw new IllegalArgumentException("A child node needs a name");
         this.parent = parent;
         this.name = name;
@@ -160,7 +160,7 @@ public class ConfigTreeBuilder implements ConfigTree {
      * @return {@code this}, for chaining
      * @see Setting
      * @see Settings
-     * @see AnnotatedSettings#applyToNode(ConfigTreeBuilder, Object)
+     * @see AnnotatedSettings#applyToNode(ConfigTree, Object)
      */
     public ConfigTreeBuilder applyFromPojo(Object pojo) throws FiberException {
         return applyFromPojo(pojo, AnnotatedSettings.DEFAULT_SETTINGS);
@@ -181,7 +181,7 @@ public class ConfigTreeBuilder implements ConfigTree {
      * @return {@code this}, for chaining
      * @see Setting @Setting
      * @see Settings @Settings
-     * @see AnnotatedSettings#applyToNode(ConfigTreeBuilder, Object)
+     * @see AnnotatedSettings#applyToNode(ConfigTree, Object)
      */
     public ConfigTreeBuilder applyFromPojo(Object pojo, AnnotatedSettings settings) throws FiberException {
         settings.applyToNode(this, pojo);
@@ -327,11 +327,12 @@ public class ConfigTreeBuilder implements ConfigTree {
     }
 
     public ConfigTreeBuilder finishBranch(Consumer<ConfigBranch> action) {
-        if (parent == null) {
-            throw new IllegalStateException("finishNode should not be called for a root node. Use build instead.");
+        if (parent instanceof ConfigTreeBuilder) {
+            action.accept(build());
+            return (ConfigTreeBuilder) parent;
+        } else {
+            throw new IllegalStateException("finishNode should not be called for a root builder. Use build instead.");
         }
-        action.accept(build());
-        return parent;
     }
 
 }

--- a/src/main/java/me/zeroeightsix/fiber/exception/DuplicateChildException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/DuplicateChildException.java
@@ -1,0 +1,7 @@
+package me.zeroeightsix.fiber.exception;
+
+public class DuplicateChildException extends IllegalStateException {
+    public DuplicateChildException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/exception/DuplicateChildException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/DuplicateChildException.java
@@ -1,7 +1,7 @@
 package me.zeroeightsix.fiber.exception;
 
-public class DuplicateChildException extends IllegalStateException {
-    public DuplicateChildException(String s) {
-        super(s);
+public class DuplicateChildException extends IllegalTreeStateException {
+    public DuplicateChildException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/me/zeroeightsix/fiber/exception/IllegalTreeStateException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/IllegalTreeStateException.java
@@ -1,0 +1,11 @@
+package me.zeroeightsix.fiber.exception;
+
+/**
+ * Signals that a {@link me.zeroeightsix.fiber.tree.ConfigTree} is not in an appropriate state for
+ * the requested operation.
+ */
+public class IllegalTreeStateException extends IllegalStateException {
+    public IllegalTreeStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/exception/RuntimeFiberException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/RuntimeFiberException.java
@@ -7,6 +7,10 @@ package me.zeroeightsix.fiber.exception;
  */
 public class RuntimeFiberException extends RuntimeException {
 
+    public RuntimeFiberException() {
+        super();
+    }
+
     public RuntimeFiberException(String s) {
         super(s);
     }

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranch.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranch.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
  */
 public interface ConfigBranch extends ConfigTree, ConfigNode, Commentable {
 
-    static ConfigTreeBuilder builder(ConfigTreeBuilder parent, String name) {
+    static ConfigTreeBuilder builder(ConfigTree parent, String name) {
         return new ConfigTreeBuilder(parent, name);
     }
 

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranch.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranch.java
@@ -4,7 +4,6 @@ import me.zeroeightsix.fiber.builder.ConfigTreeBuilder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
 
 /**
  * A node that can hold any amount of children
@@ -45,15 +44,15 @@ public interface ConfigBranch extends ConfigTree, ConfigNode, Commentable {
     ConfigNode lookup(String name);
 
     /**
-     * Returns a collection of this group's children.
+     * Returns a collection of this branch's children.
      *
-     * <p> The returned collection is unmodifiable, and guaranteed not to have two nodes with the same name.
+     * <p> The returned collection is guaranteed not to have two nodes with the same name.
      *
      * @return the set of children
      */
     @Nonnull
     @Override
-    Collection<ConfigNode> getItems();
+    NodeCollection getItems();
 
     /**
      * Returns {@code true} if this node should be serialized separately from its parent.

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranchImpl.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranchImpl.java
@@ -23,8 +23,10 @@ public class ConfigBranchImpl extends ConfigNodeImpl implements ConfigBranch {
      */
     public ConfigBranchImpl(String name, @Nullable String comment, @Nonnull Collection<ConfigNode> items, boolean serializeSeparately) {
         super(name, comment);
-        this.items = new IndexedNodeCollection(this, items);
+        this.items = new IndexedNodeCollection(this);
         this.serializeSeparately = serializeSeparately;
+        // must do 2-step initialization, to avoid leaking uninitialized <this>
+        this.items.addAll(items);
     }
 
     /**

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranchImpl.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigBranchImpl.java
@@ -4,33 +4,31 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Class implementing {@link ConfigBranch}
  */
 public class ConfigBranchImpl extends ConfigNodeImpl implements ConfigBranch {
 
-    private final Map<String, ConfigNode> items;
+    private final NodeCollection items;
     private final boolean serializeSeparately;
 
     /**
-     * Creates a new {@code ConfigGroup}.
+     * Creates a new {@code ConfigBranch}.
      *
      * @param name the name for this {@link ConfigBranchImpl}
      * @param comment the comment for this {@link ConfigBranchImpl}
      * @param items the node's items
      * @param serializeSeparately whether or not this node should be serialised separately. If {@code true}, it will be ignored during serialisation.
      */
-    public ConfigBranchImpl(String name, @Nullable String comment, @Nonnull Map<String, ConfigNode> items, boolean serializeSeparately) {
+    public ConfigBranchImpl(String name, @Nullable String comment, @Nonnull Collection<ConfigNode> items, boolean serializeSeparately) {
         super(name, comment);
-        this.items = Collections.unmodifiableMap(new TreeMap<>(items));
+        this.items = new IndexedNodeCollection(this, items);
         this.serializeSeparately = serializeSeparately;
     }
 
     /**
-     * Creates a new {@code ConfigGroup} with the provided {@code name} and {@code comment}.
+     * Creates a new {@code ConfigBranch} with the provided {@code name} and {@code comment}.
      *
      * <p> This node will not be serialised separately.
      *
@@ -38,28 +36,28 @@ public class ConfigBranchImpl extends ConfigNodeImpl implements ConfigBranch {
      * @param comment the comment for this {@link ConfigBranchImpl}
      */
     public ConfigBranchImpl(@Nonnull String name, @Nullable String comment) {
-        this(name, comment, Collections.emptyMap(), false);
+        this(name, comment, Collections.emptyList(), false);
     }
 
     /**
-     * Creates a new {@code ConfigGroup} without a name or comment.
+     * Creates a new {@code ConfigBranch} without a name or comment.
      *
      * <p> This node will not be serialised separately.
      */
     public ConfigBranchImpl() {
-        this(null, null, Collections.emptyMap(), false);
+        this(null, null, Collections.emptyList(), false);
     }
 
     @Nonnull
     @Override
-    public Collection<ConfigNode> getItems() {
-        return items.values();
+    public NodeCollection getItems() {
+        return items;
     }
 
     @Nullable
     @Override
     public ConfigNode lookup(String name) {
-        return items.get(name);
+        return items.getByName(name);
     }
 
     @Override

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
@@ -40,6 +40,7 @@ public interface ConfigNode {
      * @param parent the new parent branch for this node
      * @throws DuplicateChildException   if the new parent already has a child of the same name
      * @throws IllegalTreeStateException if this node is already attached to another branch
+     * @see NodeCollection#add(ConfigNode, boolean)
      */
     void attachTo(ConfigBranch parent) throws DuplicateChildException, IllegalTreeStateException;
 
@@ -51,6 +52,8 @@ public interface ConfigNode {
      * node's parent will be set to {@code null}.
      *
      * <p> This method has no effect is this node has no parent.
+     *
+     * @see NodeCollection#remove(Object)
      */
     void detach();
 

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
@@ -1,5 +1,7 @@
 package me.zeroeightsix.fiber.tree;
 
+import javax.annotation.Nullable;
+
 /**
  * The building block of a tree: every node implement this interface.
  */
@@ -11,5 +13,13 @@ public interface ConfigNode {
      * @return this node's name
      */
     String getName();
+
+    /**
+     * Returns this node's parent, if any.
+     *
+     * @return this node's parent, or {@code null} if it is not part of a config tree
+     */
+    @Nullable
+    ConfigBranch getParent();
 
 }

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
@@ -1,5 +1,8 @@
 package me.zeroeightsix.fiber.tree;
 
+import me.zeroeightsix.fiber.exception.DuplicateChildException;
+import me.zeroeightsix.fiber.exception.IllegalTreeStateException;
+
 import javax.annotation.Nullable;
 
 /**
@@ -21,5 +24,34 @@ public interface ConfigNode {
      */
     @Nullable
     ConfigBranch getParent();
+
+    /**
+     * Attaches this node to an existing branch.
+     *
+     * <p> After this method has returned normally, this node will be part
+     * of the branch's {@linkplain ConfigBranch#getItems() children}, and this
+     * node's parent will be set to {@code parent}.
+     *
+     * <p> If {@code parent} is {@code null}, this method does not mutate any state.
+     * It will however still throw {@code IllegalTreeStateException} if this node
+     * is not in a suitable state to be attached to another parent. To detach the node
+     * from its current parent, use {@link #detach()}.
+     *
+     * @param parent the new parent branch for this node
+     * @throws DuplicateChildException   if the new parent already has a child of the same name
+     * @throws IllegalTreeStateException if this node is already attached to another branch
+     */
+    void attachTo(ConfigBranch parent) throws DuplicateChildException, IllegalTreeStateException;
+
+    /**
+     * Detaches this node from its parent branch, if any.
+     *
+     * <p> After this method has returned, this node will be removed from
+     * the current parent's {@linkplain ConfigBranch#getItems() children}, and this
+     * node's parent will be set to {@code null}.
+     *
+     * <p> This method has no effect is this node has no parent.
+     */
+    void detach();
 
 }

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNodeImpl.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNodeImpl.java
@@ -1,5 +1,7 @@
 package me.zeroeightsix.fiber.tree;
 
+import me.zeroeightsix.fiber.exception.IllegalTreeStateException;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -54,7 +56,7 @@ public abstract class ConfigNodeImpl implements ConfigNode, Commentable {
 
     public void setParent(ConfigBranch parent) {
         if (this.parent != null && this.parent != parent) {
-            throw new IllegalStateException(this + " needs to be detached before changing the parent");
+            throw new IllegalTreeStateException(this + " needs to be detached before changing the parent");
         }
         this.parent = parent;
     }

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNodeImpl.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNodeImpl.java
@@ -16,6 +16,8 @@ public abstract class ConfigNodeImpl implements ConfigNode, Commentable {
     private final String name;
     @Nullable
     private final String comment;
+    @Nullable
+    private ConfigBranch parent;
 
     /**
      * Creates a new {@code ConfigLeaf}.
@@ -38,6 +40,23 @@ public abstract class ConfigNodeImpl implements ConfigNode, Commentable {
     @Nullable
     public String getComment() {
         return comment;
+    }
+
+    @Nullable
+    @Override
+    public ConfigBranch getParent() {
+        return this.parent;
+    }
+
+    public void detach() {
+        this.parent = null;
+    }
+
+    public void setParent(ConfigBranch parent) {
+        if (this.parent != null && this.parent != parent) {
+            throw new IllegalStateException(this + " needs to be detached before changing the parent");
+        }
+        this.parent = parent;
     }
 
     @Override

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigTree.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigTree.java
@@ -4,7 +4,6 @@ import me.zeroeightsix.fiber.builder.ConfigTreeBuilder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
 
 public interface ConfigTree {
     /**
@@ -18,11 +17,13 @@ public interface ConfigTree {
      * Returns a collection of this node's children.
      *
      * <p> The returned collection is guaranteed to have no two nodes with the same name.
+     * Any changes made to it will be reflected by this tree.
      *
      * @return the set of children
+     * @see me.zeroeightsix.fiber.NodeOperations
      */
     @Nonnull
-    Collection<ConfigNode> getItems();
+    NodeCollection getItems();
 
     /**
      * Tries to find a child in this node by name. If a child is found, it will be returned.

--- a/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
@@ -74,11 +74,11 @@ public class IndexedNodeCollection extends AbstractCollection<ConfigNode> implem
     }
 
     @Override
-    public boolean remove(@Nullable Object o) {
-        if (o instanceof ConfigNode) {
-            boolean removed = this.items.remove(((ConfigNode) o).getName(), o);
+    public boolean remove(@Nullable Object child) {
+        if (child instanceof ConfigNode) {
+            boolean removed = this.items.remove(((ConfigNode) child).getName(), child);
             if (removed) {
-                ((ConfigNode) o).detach();
+                ((ConfigNode) child).detach();
                 return true;
             }
         }

--- a/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
@@ -48,7 +48,7 @@ public class IndexedNodeCollection extends AbstractCollection<ConfigNode> implem
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Spliterator</*out*/ ConfigNode> spliterator() {
+    public Spliterator<ConfigNode> spliterator() {
         // The Spliterator interface is read-only, so we consider its element type covariant
         return (Spliterator/*<out ConfigNode>*/) this.items.values().spliterator();
     }
@@ -75,7 +75,15 @@ public class IndexedNodeCollection extends AbstractCollection<ConfigNode> implem
     }
 
     @Override
-    public boolean remove(Object o) {
+    public boolean contains(@Nullable Object o) {
+        if (o instanceof ConfigNodeImpl) {
+            return Objects.equals(this.items.get(((ConfigNode) o).getName()), o);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean remove(@Nullable Object o) {
         if (o instanceof ConfigNodeImpl) {
             boolean removed = this.items.remove(((ConfigNode) o).getName(), o);
             if (removed) {

--- a/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/IndexedNodeCollection.java
@@ -1,0 +1,108 @@
+package me.zeroeightsix.fiber.tree;
+
+import me.zeroeightsix.fiber.exception.DuplicateChildException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+
+public class IndexedNodeCollection extends AbstractCollection<ConfigNode> implements NodeCollection {
+    private final Map<String, ConfigNodeImpl> items = new TreeMap<>();
+    @Nullable private final ConfigBranch owner;
+
+    public IndexedNodeCollection(@Nullable ConfigBranch owner) {
+        this.owner = owner;
+    }
+
+    public IndexedNodeCollection(@Nullable ConfigBranch owner, Collection<ConfigNode> items) {
+        this(owner);
+        this.addAll(items);
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<ConfigNode> iterator() {
+    return new Iterator<ConfigNode>() {
+            @Nullable private ConfigNodeImpl last;
+            private Iterator<ConfigNodeImpl> backing = items.values().iterator();
+
+            @Override
+            public boolean hasNext() {
+                return backing.hasNext();
+            }
+
+            @Override
+            public ConfigNode next() {
+                this.last = this.backing.next();
+                return last;
+            }
+
+            @Override
+            public void remove() {
+                if (this.last == null) throw new IllegalStateException();
+                this.backing.remove();
+                this.last.detach();
+            }
+        };
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Spliterator</*out*/ ConfigNode> spliterator() {
+        // The Spliterator interface is read-only, so we consider its element type covariant
+        return (Spliterator/*<out ConfigNode>*/) this.items.values().spliterator();
+    }
+
+    @Override
+    public boolean add(ConfigNode item) throws DuplicateChildException {
+        return add(item, false);
+    }
+
+    @Override
+    public boolean add(ConfigNode item, boolean overwrite) throws DuplicateChildException {
+        Objects.requireNonNull(item);
+        if (!(item instanceof ConfigNodeImpl)) {
+            throw new IllegalArgumentException("Invalid config node implementation " + item);
+        }
+        if (overwrite) {
+            this.removeByName(item.getName());
+        } else if (this.items.containsKey(item.getName())) {
+            throw new DuplicateChildException("Attempt to replace node " + item.getName());
+        }
+        this.items.put(item.getName(), (ConfigNodeImpl) item);
+        ((ConfigNodeImpl) item).setParent(this.owner);
+        return true;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (o instanceof ConfigNodeImpl) {
+            boolean removed = this.items.remove(((ConfigNode) o).getName(), o);
+            if (removed) {
+                ((ConfigNodeImpl) o).detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return items.size();
+    }
+
+    @Override
+    public ConfigNode getByName(String name) {
+        return this.items.get(name);
+    }
+
+    @Override
+    @Nullable
+    public ConfigNode removeByName(String name) {
+        ConfigNodeImpl removed = this.items.remove(name);
+        if (removed != null) {
+            removed.detach();
+        }
+        return removed;
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
@@ -5,6 +5,22 @@ import me.zeroeightsix.fiber.exception.DuplicateChildException;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
+/**
+ * A specialized {@link Collection} implementation for use with nodes.
+ *
+ * <p> Elements in a node collection are considered children of the same tree.
+ * For this reason, each element of a node collection must have a distinct name.
+ * Mutating methods in this class will also update the {@linkplain ConfigNode#getParent() parent}
+ * field of added and removed elements.
+ *
+ * <p> The iterator returned by the {@code iterator} method traverses the
+ * elements in ascending name order (ie. lexicographic order of the nodes' names).
+ *
+ * <p> Null elements are not permitted. Attempts to insert a null element
+ * will throw a {@link NullPointerException}. Attempts to test for the
+ * presence of a null element or to remove one will, however, function
+ * properly.
+ */
 public interface NodeCollection extends Collection<ConfigNode> {
     /**
      * Attempts to introduce a new child to this collection.
@@ -32,10 +48,16 @@ public interface NodeCollection extends Collection<ConfigNode> {
      */
     boolean add(ConfigNode child, boolean overwrite) throws DuplicateChildException;
 
+    /**
+     * Tries to find a child in this collection by name. If a child is found, it will be returned.
+     *
+     * @param name The name of the child to look for
+     * @return the child if found, otherwise {@code null}
+     */
     ConfigNode getByName(String name);
 
     /**
-     * Attempts to remove an item from this node by name.
+     * Attempts to remove an item from this collection by name.
      *
      * @param name the name of the child that should be removed
      * @return the child if removed, otherwise {@code null}

--- a/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
@@ -42,14 +42,32 @@ public interface NodeCollection extends Collection<ConfigNode> {
     /**
      * Attempts to introduce a new child to this collection.
      *
+     * <p> If this method returns normally, the {@code child} will be attached
+     * to this collection's owner.
+     *
      * @param child      The child to add
      * @param overwrite whether existing items with the same name should be overwritten
      * @return {@code true} (as specified by {@link Collection#add})
      * @throws DuplicateChildException if there exists a child by the same name that was not overwritten
      * @throws IllegalStateException if the child cannot be added to this tree at this time
      * @throws NullPointerException if {@code node} is null
+     * @see ConfigNode#attachTo(ConfigBranch)
      */
     boolean add(ConfigNode child, boolean overwrite) throws DuplicateChildException;
+
+    /**
+     * Removes a child from this collection.
+     *
+     * <p> When this method returns, the {@code child} will be detached from
+     * this collection's owner. If the given object is not contained within this
+     * collection, this method returns {@code false} with no side effects.
+     *
+     * @param child the child to remove
+     * @return {@code true} if a node was detached as a result of this call
+     * @see ConfigNode#detach()
+     */
+    @Override
+    boolean remove(Object child);
 
     /**
      * Tries to find a child in this collection by name. If a child is found, it will be returned.

--- a/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
@@ -8,6 +8,9 @@ import java.util.Collection;
 /**
  * A specialized {@link Collection} implementation for use with nodes.
  *
+ * <p>Note: This is not a general-purpose collection.
+ * Mutating methods in this class <strong>will</strong> mutate external state.
+ *
  * <p> Elements in a node collection are considered children of the same tree.
  * For this reason, each element of a node collection must have a distinct name.
  * Mutating methods in this class will also update the {@linkplain ConfigNode#getParent() parent}

--- a/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/NodeCollection.java
@@ -1,0 +1,45 @@
+package me.zeroeightsix.fiber.tree;
+
+import me.zeroeightsix.fiber.exception.DuplicateChildException;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public interface NodeCollection extends Collection<ConfigNode> {
+    /**
+     * Attempts to introduce a new child to this collection.
+     *
+     * <p> This method behaves as if {@code add(node, false)}.
+     *
+     * @param child The child to add
+     * @return {@code true} (as specified by {@link Collection#add})
+     * @throws DuplicateChildException if there was already a child by the same name
+     * @throws IllegalStateException if the child cannot be added to this tree at this time
+     * @throws NullPointerException if {@code node} is null
+     */
+    @Override
+    boolean add(ConfigNode child) throws DuplicateChildException;
+
+    /**
+     * Attempts to introduce a new child to this collection.
+     *
+     * @param child      The child to add
+     * @param overwrite whether existing items with the same name should be overwritten
+     * @return {@code true} (as specified by {@link Collection#add})
+     * @throws DuplicateChildException if there exists a child by the same name that was not overwritten
+     * @throws IllegalStateException if the child cannot be added to this tree at this time
+     * @throws NullPointerException if {@code node} is null
+     */
+    boolean add(ConfigNode child, boolean overwrite) throws DuplicateChildException;
+
+    ConfigNode getByName(String name);
+
+    /**
+     * Attempts to remove an item from this node by name.
+     *
+     * @param name the name of the child that should be removed
+     * @return the child if removed, otherwise {@code null}
+     */
+    @Nullable
+    ConfigNode removeByName(String name);
+}

--- a/src/test/java/me/zeroeightsix/fiber/NodeOperationsTest.java
+++ b/src/test/java/me/zeroeightsix/fiber/NodeOperationsTest.java
@@ -15,7 +15,7 @@ class NodeOperationsTest {
 
     @Test
     @DisplayName("Node -> Node")
-    void mergeTo() {
+    void moveChildren() {
         ConfigTree treeOne = ConfigTree.builder()
                 .beginValue("A", Integer.class)
                 .withDefaultValue(10)
@@ -24,27 +24,27 @@ class NodeOperationsTest {
 
         ConfigTreeBuilder nodeTwo = ConfigTree.builder();
 
-        NodeOperations.mergeTo(treeOne, nodeTwo);
+        NodeOperations.moveChildren(treeOne, nodeTwo);
 
         testNodeFor(nodeTwo, "A", Integer.class, 10);
     }
 
     @Test
     @DisplayName("Value -> Node")
-    void mergeTo1() {
+    void moveNode() {
         ConfigTreeBuilder node = ConfigTree.builder();
         ConfigLeaf<Integer> value = node.beginValue("A", Integer.class)
                 .withDefaultValue(10)
                 .build();
 
-        NodeOperations.mergeTo(value, node);
+        NodeOperations.moveNode(value, node);
 
         testNodeFor(node, "A", Integer.class, 10);
     }
 
     @Test
     @DisplayName("Value -> Value")
-    void mergeTo2() {
+    void copyValue() {
         ConfigLeaf<Integer> valueOne = new ConfigLeafBuilder<>(null, "A", Integer.class)
                 .withDefaultValue(10)
                 .build();
@@ -52,7 +52,7 @@ class NodeOperationsTest {
                 .withDefaultValue(20)
                 .build();
 
-        NodeOperations.mergeTo(valueOne, valueTwo);
+        NodeOperations.copyValue(valueOne, valueTwo);
         testItemFor(Integer.class, 10, valueTwo);
     }
 


### PR DESCRIPTION
# 🦀Mutability is back 🦀

Immutability is cool and all, but sometimes you want to mutate your (or someone else's) configuration 
tree without doing a big mess. This would be especially useful for meta-configuration such as node attributes, where the same config trees are shared by every plugin.

## Introducing `NodeCollection`

Instead of adding back some mutation methods to the `ConfigTree` class, I went for a new Collection type. This enables sharing logic between `ConfigBranch` and `ConfigTreeBuilder`, as well as better defining the properties of `ConfigTree#getItems()`. It also allows more complex operations on config trees by offering interoperability with existing Collection handling facilities.

## Other changes
- General-purpose methods that previously mutated a `ConfigTreeBuilder` now accept any `ConfigTree`.
- Nodes now track their parent. This avoids annoying bugs due to duplicate references, and facilitates some tree traversal operations.
    - `ConfigTreeBuilder` does not automatically throw on successive builds any more
- `NodeOperations` now perform move operations instead of shallow copies.