### PR TITLE
Improve enum types support

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/EnumSerializableType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/EnumSerializableType.java
@@ -2,7 +2,7 @@ package io.github.fablabsmc.fablabs.api.fiber.v1.schema.type;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -14,12 +14,12 @@ public final class EnumSerializableType extends SerializableType<String> {
 	private final Set<String> validValues;
 
 	public EnumSerializableType(String... validValues) {
-		this(new HashSet<>(Arrays.asList(validValues)));
+		this(new LinkedHashSet<>(Arrays.asList(validValues)));
 	}
 
 	public EnumSerializableType(Set<String> validValues) {
 		super(String.class, EnumConstraintChecker.instance());
-		this.validValues = Collections.unmodifiableSet(new HashSet<>(validValues));
+		this.validValues = Collections.unmodifiableSet(new LinkedHashSet<>(validValues));
 	}
 
 	public Set<String> getValidValues() {

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypes.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypes.java
@@ -114,6 +114,7 @@ public final class ConfigTypes {
 	 * @return An {@link EnumConfigType} holding a value of {@code E}.
 	 */
 	public static <E extends Enum<E>> EnumConfigType<E> makeEnum(Class<E> enumType) {
+		if (!enumType.isEnum()) throw new IllegalArgumentException(enumType + " is not an enum declaration");
 		Set<String> validValues = Arrays.stream(enumType.getEnumConstants()).map(Enum::name).collect(Collectors.toSet());
 		return new EnumConfigType<>(new EnumSerializableType(validValues), enumType, e -> Enum.valueOf(enumType, e), Enum::name);
 	}

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypes.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypes.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -115,7 +115,8 @@ public final class ConfigTypes {
 	 */
 	public static <E extends Enum<E>> EnumConfigType<E> makeEnum(Class<E> enumType) {
 		if (!enumType.isEnum()) throw new IllegalArgumentException(enumType + " is not an enum declaration");
-		Set<String> validValues = Arrays.stream(enumType.getEnumConstants()).map(Enum::name).collect(Collectors.toSet());
+		// map constants to their names, while preserving natural ordering
+		Set<String> validValues = Arrays.stream(enumType.getEnumConstants()).map(Enum::name).collect(Collectors.toCollection(LinkedHashSet::new));
 		return new EnumConfigType<>(new EnumSerializableType(validValues), enumType, e -> Enum.valueOf(enumType, e), Enum::name);
 	}
 
@@ -177,7 +178,7 @@ public final class ConfigTypes {
 				new ListSerializableType<>(elementType.getSerializedType(), 0, Integer.MAX_VALUE, true),
 				Set.class,
 				l -> {
-					Set<E> ret = new HashSet<>();
+					Set<E> ret = new LinkedHashSet<>();
 
 					for (S s : l) {
 						ret.add(elementType.toRuntimeType(s));

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -286,8 +286,8 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 	private Map<String, List<Member>> findListeners(Class<?> pojoClass) {
 		return Stream.concat(Arrays.stream(pojoClass.getDeclaredFields()), Arrays.stream(pojoClass.getDeclaredMethods()))
-						.filter(accessibleObject -> accessibleObject.isAnnotationPresent(Listener.class))
-						.collect(Collectors.groupingBy(accessibleObject -> ((AccessibleObject) accessibleObject).getAnnotation(Listener.class).value()));
+				.filter(accessibleObject -> accessibleObject.isAnnotationPresent(Listener.class))
+				.collect(Collectors.groupingBy(accessibleObject -> ((AccessibleObject) accessibleObject).getAnnotation(Listener.class).value()));
 	}
 
 	private static boolean isIncluded(Field field, boolean onlyAnnotated) {
@@ -326,7 +326,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		@SuppressWarnings("unchecked") ConfigType<R, S, ?> type = (ConfigType<R, S, ?>) this.toConfigType(field.getAnnotatedType());
 
 		ConfigLeafBuilder<S, R> builder = node.beginValue(name, type, this.findDefaultValue(field, pojo))
-						.withComment(findComment(field));
+				.withComment(findComment(field));
 
 		for (Member listener : listeners) {
 			BiConsumer<R, R> consumer = this.constructListener(listener, pojo, type.getRuntimeType());
@@ -394,11 +394,11 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 			ret = ConfigTypes.makeEnum(clazz.asSubclass(Enum.class));
 		} else {
 			Optional<Class<?>> closestParent = Stream.concat(this.registeredGenericTypes.keySet().stream(), this.registeredTypes.keySet().stream())
-							.filter(c -> c.isAssignableFrom(clazz))
-							.reduce((c1, c2) -> c1.isAssignableFrom(c2) ? c2 : c1);
+					.filter(c -> c.isAssignableFrom(clazz))
+					.reduce((c1, c2) -> c1.isAssignableFrom(c2) ? c2 : c1);
 			String closestParentSuggestion = closestParent.map(p -> "declaring the element as '" + p.getTypeName() + "', or ").orElse("");
 			throw new FiberTypeProcessingException("Unknown config type " + annotatedType.getType().getTypeName()
-							+ ". Consider marking as transient, or " + closestParentSuggestion + "registering a new Class -> ConfigType mapping.");
+					+ ". Consider marking as transient, or " + closestParentSuggestion + "registering a new Class -> ConfigType mapping.");
 		}
 
 		assert ret != null;
@@ -436,7 +436,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 		for (Annotation annotation : annotated.getAnnotations()) {
 			@SuppressWarnings("unchecked") ConstraintAnnotationProcessor<Annotation> processor =
-							(ConstraintAnnotationProcessor<Annotation>) this.constraintProcessors.get(annotation.annotationType());
+					(ConstraintAnnotationProcessor<Annotation>) this.constraintProcessors.get(annotation.annotationType());
 			if (processor != null) {
 				try {
 					ret = this.constrain(ret, processor, annotation, annotated);
@@ -556,11 +556,11 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 	private static String findName(Field field, SettingNamingConvention convention) {
 		return Optional.ofNullable(
-						field.isAnnotationPresent(Setting.Group.class)
-										? field.getAnnotation(Setting.Group.class).name()
-										: getSettingAnnotation(field).map(Setting::name).orElse(null))
-						.filter(s -> !s.isEmpty())
-						.orElse(convention.name(field.getName()));
+				field.isAnnotationPresent(Setting.Group.class)
+						? field.getAnnotation(Setting.Group.class).name()
+						: getSettingAnnotation(field).map(Setting::name).orElse(null))
+				.filter(s -> !s.isEmpty())
+				.orElse(convention.name(field.getName()));
 	}
 
 	private static SettingNamingConvention createConvention(Class<? extends SettingNamingConvention> namingConvention) throws FiberException {

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -25,6 +25,8 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
+
 import io.github.fablabsmc.fablabs.api.fiber.v1.NodeOperations;
 import io.github.fablabsmc.fablabs.api.fiber.v1.annotation.AnnotatedSettings;
 import io.github.fablabsmc.fablabs.api.fiber.v1.annotation.Listener;
@@ -284,8 +286,8 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 	private Map<String, List<Member>> findListeners(Class<?> pojoClass) {
 		return Stream.concat(Arrays.stream(pojoClass.getDeclaredFields()), Arrays.stream(pojoClass.getDeclaredMethods()))
-				.filter(accessibleObject -> accessibleObject.isAnnotationPresent(Listener.class))
-				.collect(Collectors.groupingBy(accessibleObject -> ((AccessibleObject) accessibleObject).getAnnotation(Listener.class).value()));
+						.filter(accessibleObject -> accessibleObject.isAnnotationPresent(Listener.class))
+						.collect(Collectors.groupingBy(accessibleObject -> ((AccessibleObject) accessibleObject).getAnnotation(Listener.class).value()));
 	}
 
 	private static boolean isIncluded(Field field, boolean onlyAnnotated) {
@@ -324,7 +326,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		@SuppressWarnings("unchecked") ConfigType<R, S, ?> type = (ConfigType<R, S, ?>) this.toConfigType(field.getAnnotatedType());
 
 		ConfigLeafBuilder<S, R> builder = node.beginValue(name, type, this.findDefaultValue(field, pojo))
-				.withComment(findComment(field));
+						.withComment(findComment(field));
 
 		for (Member listener : listeners) {
 			BiConsumer<R, R> consumer = this.constructListener(listener, pojo, type.getRuntimeType());
@@ -356,6 +358,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		}
 	}
 
+	@Nonnull
 	private ConfigType<?, ?, ?> toConfigType(AnnotatedType annotatedType) throws FiberTypeProcessingException {
 		Class<?> clazz = TypeMagic.classForType(annotatedType.getType());
 
@@ -363,13 +366,13 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 			throw new FiberTypeProcessingException("Unknown type " + annotatedType.getType().getTypeName());
 		}
 
-		ConfigType<?, ?, ?> ret;
+		@Nonnull ConfigType<?, ?, ?> ret;
 
 		if (annotatedType instanceof AnnotatedArrayType) {
 			ConfigType<?, ?, ?> componentType = this.toConfigType(((AnnotatedArrayType) annotatedType).getAnnotatedGenericComponentType());
 			Class<?> componentClass = clazz.getComponentType();
 			assert componentClass != null;
-			ret = makeArrayConfigType(componentClass, componentType);
+			ret = this.makeArrayConfigType(componentClass, componentType);
 		} else if (this.registeredGenericTypes.containsKey(clazz)) {
 			ParameterizedTypeProcessor<?> parameterizedTypeProcessor = this.registeredGenericTypes.get(clazz);
 
@@ -385,19 +388,20 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 			}
 
 			ret = parameterizedTypeProcessor.process(typeArguments);
-		} else {
+		} else if (this.registeredTypes.containsKey(clazz)) {
 			ret = this.registeredTypes.get(clazz);
-		}
-
-		if (ret == null) {
+		} else if (clazz.isEnum()) {
+			ret = ConfigTypes.makeEnum(clazz.asSubclass(Enum.class));
+		} else {
 			Optional<Class<?>> closestParent = Stream.concat(this.registeredGenericTypes.keySet().stream(), this.registeredTypes.keySet().stream())
-					.filter(c -> c.isAssignableFrom(clazz))
-					.reduce((c1, c2) -> c1.isAssignableFrom(c2) ? c2 : c1);
+							.filter(c -> c.isAssignableFrom(clazz))
+							.reduce((c1, c2) -> c1.isAssignableFrom(c2) ? c2 : c1);
 			String closestParentSuggestion = closestParent.map(p -> "declaring the element as '" + p.getTypeName() + "', or ").orElse("");
 			throw new FiberTypeProcessingException("Unknown config type " + annotatedType.getType().getTypeName()
-					+ ". Consider marking as transient, or " + closestParentSuggestion + "registering a new Class -> ConfigType mapping.");
+							+ ". Consider marking as transient, or " + closestParentSuggestion + "registering a new Class -> ConfigType mapping.");
 		}
 
+		assert ret != null;
 		return this.constrain(ret, annotatedType);
 	}
 
@@ -432,7 +436,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 		for (Annotation annotation : annotated.getAnnotations()) {
 			@SuppressWarnings("unchecked") ConstraintAnnotationProcessor<Annotation> processor =
-					(ConstraintAnnotationProcessor<Annotation>) this.constraintProcessors.get(annotation.annotationType());
+							(ConstraintAnnotationProcessor<Annotation>) this.constraintProcessors.get(annotation.annotationType());
 			if (processor != null) {
 				try {
 					ret = this.constrain(ret, processor, annotation, annotated);
@@ -552,11 +556,11 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 	private static String findName(Field field, SettingNamingConvention convention) {
 		return Optional.ofNullable(
-				field.isAnnotationPresent(Setting.Group.class)
-						? field.getAnnotation(Setting.Group.class).name()
-						: getSettingAnnotation(field).map(Setting::name).orElse(null))
-				.filter(s -> !s.isEmpty())
-				.orElse(convention.name(field.getName()));
+						field.isAnnotationPresent(Setting.Group.class)
+										? field.getAnnotation(Setting.Group.class).name()
+										: getSettingAnnotation(field).map(Setting::name).orElse(null))
+						.filter(s -> !s.isEmpty())
+						.orElse(convention.name(field.getName()));
 	}
 
 	private static SettingNamingConvention createConvention(Class<? extends SettingNamingConvention> namingConvention) throws FiberException {

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -231,6 +231,19 @@ class AnnotatedSettingsTest {
 	}
 
 	@Test
+	@DisplayName("Enum")
+	void testEnum() throws FiberException {
+		EnumPojo pojo = new EnumPojo();
+		this.annotatedSettings.applyToNode(this.node, pojo);
+		assertEquals(1, this.node.getItems().size(), "Node has one item");
+		ConfigNode child = this.node.lookup("a");
+		assertTrue(child instanceof ConfigLeaf);
+		ConfigLeaf<?> leaf = (ConfigLeaf<?>) child;
+		assertEquals(ConfigTypes.makeEnum(EnumPojo.TestEnum.class).getSerializedType(), leaf.getConfigType());
+		assertEquals("A", leaf.getValue());
+	}
+
+	@Test
 	@DisplayName("Commented setting")
 	void testComment() throws FiberException {
 		CommentPojo pojo = new CommentPojo();
@@ -354,6 +367,19 @@ class AnnotatedSettingsTest {
 		// we want to test this edge case
 		class SubNode {
 			private int b = 5;
+		}
+	}
+
+	private static class EnumPojo {
+		public TestEnum a = TestEnum.A;
+
+		enum TestEnum {
+			A {
+				@Override
+				public String toString() {
+					return "hi";
+				}
+			}, B, C
 		}
 	}
 }


### PR DESCRIPTION
Enums currently need to have a matching `ConfigType` manually registered to be used in `AnnotatedSettings`. Considering how common enum values are in configs, this behaviour is quite suboptimal.

This PR introduces a default handling path for enum type declarations in POJOs. It also adds a fail-fast check in ConfigTypes#makeEnum to avoid some sneaky NPEs. Note that we do not support anonymous classes resulting from specialized enum constants, though that could be added in the future.