### PR TITLE
Add missing implementation for ConfigTreeBuilder#withMirroredValue

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
@@ -336,9 +336,31 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 		return this;
 	}
 
-	public <R, S> ConfigTreeBuilder withMirroredValue(@Nonnull String name, @Nonnull ConfigType<R, S, ?> type, @Nullable R defaultValue) {
-		this.items.add(new ConfigLeafImpl<>(name, type.getSerializedType(), null, type.toSerializedType(defaultValue), (a, b) -> {
-		}));
+	/**
+	 * Adds a {@code ConfigLeaf} bound to a {@link PropertyMirror}, using the mirror's type information.
+	 *
+	 * <p> This method behaves as if:
+	 * <pre>{@code this.beginValue(name, mirror.getMirroredType(), defaultValue).finishValue(mirror::mirror)}</pre>
+	 *
+	 * <p><strong>The built leaf will only accept values of the {@code mirror}'s
+	 * {@linkplain ConfigType#getSerializedType() serializable config type}</strong>.
+	 * The full derived type information is only used to convert the provided {@code defaultValue}
+	 * to a valid serialized form. The mirror can be used to interact seamlessly
+	 * with the leaf using runtime types.
+	 *
+	 * <p> This method allows only basic configuration of the created leaf.
+	 * For more flexibility, {@link #beginValue} can be used.
+	 *
+	 * @param name         the name of the child leaf
+	 * @param mirror       a mirror to be bound to the leaf
+	 * @param defaultValue the runtime representation of the default value of the {@link ConfigLeaf} to create.
+	 * @param <R>          the runtime type of the {@code defaultValue} representation.
+	 * @return {@code this}, for chaining
+	 * @see #beginValue(String, SerializableType, Object)
+	 * @see ConfigTypes
+	 */
+	public <R> ConfigTreeBuilder withMirroredValue(@Nonnull String name, @Nonnull PropertyMirror<R> mirror, @Nullable R defaultValue) {
+		this.beginValue(name, mirror.getMirroredType(), defaultValue).finishValue(mirror::mirror);
 		return this;
 	}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
@@ -120,7 +120,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 
 	@Override
 	public boolean lookupAndBind(String name, PropertyMirror<?> mirror) {
-		ConfigLeaf<?> leaf = this.lookupLeaf(name, mirror.getConverter().getSerializedType());
+		ConfigLeaf<?> leaf = this.lookupLeaf(name, mirror.getMirroredType().getSerializedType());
 
 		if (leaf != null) {
 			mirror.mirror(leaf);

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/PropertyMirror.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/PropertyMirror.java
@@ -37,5 +37,5 @@ public interface PropertyMirror<T> extends Property<T> {
 
 	Property<?> getMirrored();
 
-	ConfigType<T, ?, ?> getConverter();
+	ConfigType<T, ?, ?> getMirroredType();
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigBranchImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigBranchImpl.java
@@ -84,7 +84,7 @@ public class ConfigBranchImpl extends ConfigNodeImpl implements ConfigBranch {
 
 	@Override
 	public boolean lookupAndBind(String name, PropertyMirror<?> mirror) {
-		ConfigLeaf<?> leaf = this.lookupLeaf(name, mirror.getConverter().getSerializedType());
+		ConfigLeaf<?> leaf = this.lookupLeaf(name, mirror.getMirroredType().getSerializedType());
 
 		if (leaf != null) {
 			mirror.mirror(leaf);

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
@@ -11,14 +11,14 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.PropertyMirror;
 
 public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 	protected Property<S> delegate;
-	protected ConfigType<R, S, ?> converter;
+	protected ConfigType<R, S, ?> mirroredType;
 	@Nullable
 	private S lastSerializedValue;
 	@Nullable
 	private R cachedValue;
 
-	public PropertyMirrorImpl(ConfigType<R, S, ?> converter) {
-		this.converter = converter;
+	public PropertyMirrorImpl(ConfigType<R, S, ?> mirroredType) {
+		this.mirroredType = mirroredType;
 	}
 
 	/**
@@ -31,8 +31,8 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 	 */
 	@Override
 	public void mirror(Property<?> delegate) {
-		if (!this.converter.getSerializedType().getPlatformType().equals(delegate.getType())) {
-			throw new IllegalArgumentException("Unsupported delegate type " + delegate.getType() + ", should be " + this.converter.getSerializedType().getPlatformType());
+		if (!this.mirroredType.getSerializedType().getPlatformType().equals(delegate.getType())) {
+			throw new IllegalArgumentException("Unsupported delegate type " + delegate.getType() + ", should be " + this.mirroredType.getSerializedType().getPlatformType());
 		}
 
 		@SuppressWarnings("unchecked") Property<S> d = (Property<S>) delegate;
@@ -56,13 +56,13 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 	@Override
 	public boolean setValue(R value) {
 		if (this.delegate == null) throw new IllegalStateException("No delegate property set for this mirror");
-		return this.delegate.setValue(this.converter.toPlatformType(value));
+		return this.delegate.setValue(this.mirroredType.toPlatformType(value));
 	}
 
 	@Override
 	public boolean accepts(R value) {
 		if (this.delegate == null) throw new IllegalStateException("No delegate property set for this mirror");
-		return this.delegate.accepts(this.converter.toPlatformType(value));
+		return this.delegate.accepts(this.mirroredType.toPlatformType(value));
 	}
 
 	@Override
@@ -73,7 +73,7 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 			S serializedValue = this.delegate.getValue();
 
 			if (!Objects.equals(this.lastSerializedValue, serializedValue)) {
-				this.cachedValue = this.converter.toRuntimeType(serializedValue);
+				this.cachedValue = this.mirroredType.toRuntimeType(serializedValue);
 				this.lastSerializedValue = serializedValue;
 			}
 		}
@@ -83,11 +83,11 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 
 	@Override
 	public Class<R> getType() {
-		return this.converter.getRuntimeType();
+		return this.mirroredType.getRuntimeType();
 	}
 
 	@Override
-	public ConfigType<R, S, ?> getConverter() {
-		return this.converter;
+	public ConfigType<R, S, ?> getMirroredType() {
+		return this.mirroredType;
 	}
 }


### PR DESCRIPTION
It is said that helper methods are more helpful when they work.

This PR also renames the `converter` field in `PropertyMirror`, as it's a bit more than just a converter.