### PR TITLE
Improve enum and numeric constraint methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 major = 0
-minor = 20
-patch = 1
+minor = 21
+patch = 0

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/EnumConfigType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/EnumConfigType.java
@@ -2,7 +2,10 @@ package io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.github.fablabsmc.fablabs.api.fiber.v1.annotation.processor.ConstraintAnnotationProcessor;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.EnumSerializableType;
@@ -27,5 +30,16 @@ public final class EnumConfigType<T> extends ConfigType<T, String, EnumSerializa
 	@Override
 	public EnumConfigType<T> constrain(ConstraintAnnotationProcessor<Annotation> processor, Annotation annotation, AnnotatedElement annotated) {
 		return processor.processEnum(this, annotation, annotated);
+	}
+
+	public EnumConfigType<T> withValues(Set<? extends T> values) {
+		Set<String> strValues = values.stream().map(this::toSerializedType).collect(Collectors.toSet());
+		return this.withType(new EnumSerializableType(strValues));
+	}
+
+	@SafeVarargs
+	public final EnumConfigType<T> withValues(T... values) {
+		Set<String> strValues = Arrays.stream(values).map(this::toSerializedType).collect(Collectors.toSet());
+		return this.withType(new EnumSerializableType(strValues));
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/NumberConfigType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/NumberConfigType.java
@@ -5,8 +5,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.math.BigDecimal;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
-
 import io.github.fablabsmc.fablabs.api.fiber.v1.annotation.processor.ConstraintAnnotationProcessor;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.DecimalSerializableType;
 
@@ -32,27 +30,22 @@ public final class NumberConfigType<T> extends ConfigType<T, BigDecimal, Decimal
 		return processor.processDecimal(this, annotation, annotated);
 	}
 
-	public NumberConfigType<T> withMinimum(Number min) {
+	public NumberConfigType<T> withMinimum(T min) {
 		DecimalSerializableType current = this.getSerializedType();
-		return this.withType(new DecimalSerializableType(this.toBigDecimal(min), current.getMaximum(), current.getIncrement()));
+		return this.withType(new DecimalSerializableType(this.toSerializedType(min), current.getMaximum(), current.getIncrement()));
 	}
 
-	public NumberConfigType<T> withMaximum(Number max) {
+	public NumberConfigType<T> withMaximum(T max) {
 		DecimalSerializableType current = this.getSerializedType();
-		return this.withType(new DecimalSerializableType(current.getMinimum(), this.toBigDecimal(max), current.getIncrement()));
+		return this.withType(new DecimalSerializableType(current.getMinimum(), this.toSerializedType(max), current.getIncrement()));
 	}
 
-	public NumberConfigType<T> withIncrement(Number step) {
+	public NumberConfigType<T> withIncrement(T step) {
 		DecimalSerializableType current = this.getSerializedType();
-		return this.withType(new DecimalSerializableType(current.getMinimum(), current.getMaximum(), this.toBigDecimal(step)));
+		return this.withType(new DecimalSerializableType(current.getMinimum(), current.getMaximum(), this.toSerializedType(step)));
 	}
 
-	public NumberConfigType<T> withValidRange(Number min, Number max, Number step) {
-		return this.withType(new DecimalSerializableType(this.toBigDecimal(min), this.toBigDecimal(max), this.toBigDecimal(step)));
-	}
-
-	@Nonnull
-	private BigDecimal toBigDecimal(Number t) {
-		return new BigDecimal(t.toString());
+	public NumberConfigType<T> withValidRange(T min, T max, T step) {
+		return this.withType(new DecimalSerializableType(this.toSerializedType(min), this.toSerializedType(max), this.toSerializedType(step)));
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -43,6 +43,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.exception.FiberException;
 import io.github.fablabsmc.fablabs.api.fiber.v1.exception.FiberTypeProcessingException;
 import io.github.fablabsmc.fablabs.api.fiber.v1.exception.MalformedFieldException;
 import io.github.fablabsmc.fablabs.api.fiber.v1.exception.RuntimeFiberException;
+import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.DecimalSerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigTypes;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ListConfigType;
@@ -86,41 +87,47 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		this.registerConstraintProcessor(Setting.Constrain.Range.class, new ConstraintAnnotationProcessor<Setting.Constrain.Range>() {
 			@Override
 			public <T> NumberConfigType<T> processDecimal(NumberConfigType<T> baseType, Setting.Constrain.Range annotation, AnnotatedElement annotated) {
-				NumberConfigType<T> ret = baseType;
+				DecimalSerializableType serType = baseType.getSerializedType();
+				BigDecimal min = serType.getMaximum();
+				BigDecimal max = serType.getMaximum();
+				BigDecimal inc = serType.getIncrement();
 
 				if (annotation.min() > Double.NEGATIVE_INFINITY) {
-					ret = ret.withMinimum(annotation.min());
+					min = BigDecimal.valueOf(annotation.min());
 				}
 
 				if (annotation.max() < Double.POSITIVE_INFINITY) {
-					ret = ret.withMaximum(annotation.max());
+					max = BigDecimal.valueOf(annotation.max());
 				}
 
 				if (annotation.step() > Double.MIN_VALUE) {
-					ret = ret.withIncrement(annotation.step());
+					inc = BigDecimal.valueOf(annotation.step());
 				}
 
-				return ret;
+				return baseType.withType(new DecimalSerializableType(min, max, inc));
 			}
 		});
 		this.registerConstraintProcessor(Setting.Constrain.BigRange.class, new ConstraintAnnotationProcessor<Setting.Constrain.BigRange>() {
 			@Override
 			public <T> NumberConfigType<T> processDecimal(NumberConfigType<T> baseType, Setting.Constrain.BigRange annotation, AnnotatedElement annotated) {
-				NumberConfigType<T> ret = baseType;
+				DecimalSerializableType serType = baseType.getSerializedType();
+				BigDecimal min = serType.getMaximum();
+				BigDecimal max = serType.getMaximum();
+				BigDecimal inc = serType.getIncrement();
 
 				if (!annotation.min().isEmpty()) {
-					ret = ret.withMinimum(new BigDecimal(annotation.min()));
+					min = new BigDecimal(annotation.min());
 				}
 
 				if (!annotation.max().isEmpty()) {
-					ret = ret.withMaximum(new BigDecimal(annotation.max()));
+					max = new BigDecimal(annotation.max());
 				}
 
 				if (!annotation.step().isEmpty()) {
-					ret = ret.withIncrement(new BigDecimal(annotation.step()));
+					inc = new BigDecimal(annotation.step());
 				}
 
-				return ret;
+				return baseType.withType(new DecimalSerializableType(min, max, inc));
 			}
 		});
 		this.registerConstraintProcessor(Setting.Constrain.MinLength.class, new ConstraintAnnotationProcessor<Setting.Constrain.MinLength>() {

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
@@ -118,4 +118,24 @@ class ConfigTypesTest {
 		assertEquals(ls, type.toSerializedType(arr), "Convert String[] -> List<String>");
 		assertArrayEquals(arr, type.toRuntimeType(ls), "Convert List<String> -> String[]");
 	}
+
+	enum TestEnum { A, B }
+
+	@Test
+	void testEnum() {
+		EnumConfigType<TestEnum> type = ConfigTypes.makeEnum(TestEnum.class);
+		Predicate<TestEnum> constraint = a -> type.getSerializedType().accepts(type.toSerializedType(a));
+		assertTrue(constraint.test(TestEnum.A), "Unconstrained enum accepts A");
+		assertTrue(constraint.test(TestEnum.B), "Unconstrained enum accepts B");
+
+		EnumConfigType<TestEnum> constrainedType = type.withValues(TestEnum.A);
+		constraint = a -> constrainedType.getSerializedType().accepts(type.toSerializedType(a));
+		assertTrue(constraint.test(TestEnum.A), "Constrained enum 1 enum accepts A");
+		assertFalse(constraint.test(TestEnum.B), "Constrained enum 1 does not accept B");
+
+		EnumConfigType<TestEnum> constrainedType2 = type.withValues(Collections.singleton(TestEnum.B));
+		constraint = a -> constrainedType2.getSerializedType().accepts(type.toSerializedType(a));
+		assertFalse(constraint.test(TestEnum.A), "Constrained enum 2 does not accept A");
+		assertTrue(constraint.test(TestEnum.B), "Constrained enum 2 accepts B");
+	}
 }

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
@@ -27,7 +27,7 @@ class ConfigTypesTest {
 	@DisplayName("Test numerical constraints")
 	@Test
 	void testNumericalConstraints() {
-		assertThrows(IllegalStateException.class, () -> ConfigTypes.UNBOUNDED_DECIMAL.withIncrement(5), "Increment without a minimum");
+		assertThrows(IllegalStateException.class, () -> ConfigTypes.UNBOUNDED_DECIMAL.withIncrement(BigDecimal.valueOf(5)), "Increment without a minimum");
 		assertThrows(IllegalArgumentException.class, () -> ConfigTypes.INTEGER.withIncrement(-5), "Negative increment");
 
 		DecimalSerializableType type = ConfigTypes.NATURAL.withMinimum(10).withMaximum(20).getSerializedType();


### PR DESCRIPTION
- NumberConfigType takes a `T` in each of its constraint methods
- EnumConfigType now has `withValues` methods that take a `Set<T>` or a `T[]`