### PR TITLE
Ensure config values are always nonnull.

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigLeafBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigLeafBuilder.java
@@ -151,7 +151,7 @@ public class ConfigLeafBuilder<T, R> extends ConfigNodeBuilder {
 	 * @return {@code this} builder
 	 */
 	public ConfigLeafBuilder<T, R> withDefaultValue(R defaultValue) {
-		this.defaultValue = this.serializer.apply(defaultValue);
+		this.defaultValue = this.serializer.apply(Objects.requireNonNull(defaultValue));
 		return this;
 	}
 
@@ -167,10 +167,12 @@ public class ConfigLeafBuilder<T, R> extends ConfigNodeBuilder {
 	 */
 	@Override
 	public ConfigLeaf<T> build() {
-		if (this.defaultValue != null) {
-			if (!this.type.accepts(this.defaultValue)) {
-				throw new RuntimeFiberException("Default value '" + this.defaultValue + "' does not satisfy constraints on type " + this.type);
-			}
+		if (this.defaultValue == null) {
+			throw new RuntimeFiberException("Default value is null; a default value must be set before building");
+		}
+
+		if (!this.type.accepts(this.defaultValue)) {
+			throw new RuntimeFiberException("Default value '" + this.defaultValue + "' does not satisfy constraints on type " + this.type);
 		}
 
 		ConfigLeaf<T> built = new ConfigLeafImpl<>(Objects.requireNonNull(name, "Cannot build a value without a name"), type, comment, defaultValue, consumer);

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
@@ -282,11 +282,23 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	 * @see ConfigTypes
 	 */
 	public <T> ConfigLeafBuilder<T, T> beginValue(@Nonnull String name, @Nonnull SerializableType<T> type, @Nullable T defaultValue) {
-		return ConfigLeafBuilder.create(this, name, type).withDefaultValue(defaultValue);
+		ConfigLeafBuilder<T, T> ret = ConfigLeafBuilder.create(this, name, type);
+
+		if (defaultValue != null) {
+			ret = ret.withDefaultValue(defaultValue);
+		}
+
+		return ret;
 	}
 
 	public <T, R> ConfigLeafBuilder<T, R> beginValue(@Nonnull String name, @Nonnull ConfigType<R, T, ?> type, @Nullable R defaultValue) {
-		return ConfigLeafBuilder.create(this, name, type).withDefaultValue(defaultValue);
+		ConfigLeafBuilder<T, R> ret = ConfigLeafBuilder.create(this, name, type);
+
+		if (defaultValue != null) {
+			ret = ret.withDefaultValue(defaultValue);
+		}
+
+		return ret;
 	}
 
 	/**
@@ -303,7 +315,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	 * @see #beginValue(String, SerializableType, Object)
 	 * @see ConfigTypes
 	 */
-	public <T> ConfigTreeBuilder withValue(@Nonnull String name, @Nonnull SerializableType<T> type, @Nullable T defaultValue) {
+	public <T> ConfigTreeBuilder withValue(@Nonnull String name, @Nonnull SerializableType<T> type, @Nonnull T defaultValue) {
 		this.items.add(new ConfigLeafImpl<>(name, type, null, defaultValue, (a, b) -> {
 		}));
 		return this;

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
@@ -281,24 +281,12 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	 * @see ConfigLeafBuilder
 	 * @see ConfigTypes
 	 */
-	public <T> ConfigLeafBuilder<T, T> beginValue(@Nonnull String name, @Nonnull SerializableType<T> type, @Nullable T defaultValue) {
-		ConfigLeafBuilder<T, T> ret = ConfigLeafBuilder.create(this, name, type);
-
-		if (defaultValue != null) {
-			ret = ret.withDefaultValue(defaultValue);
-		}
-
-		return ret;
+	public <T> ConfigLeafBuilder<T, T> beginValue(@Nonnull String name, @Nonnull SerializableType<T> type, @Nonnull T defaultValue) {
+		return ConfigLeafBuilder.create(this, name, type, defaultValue);
 	}
 
-	public <T, R> ConfigLeafBuilder<T, R> beginValue(@Nonnull String name, @Nonnull ConfigType<R, T, ?> type, @Nullable R defaultValue) {
-		ConfigLeafBuilder<T, R> ret = ConfigLeafBuilder.create(this, name, type);
-
-		if (defaultValue != null) {
-			ret = ret.withDefaultValue(defaultValue);
-		}
-
-		return ret;
+	public <T, R> ConfigLeafBuilder<T, R> beginValue(@Nonnull String name, @Nonnull ConfigType<R, T, ?> type, @Nonnull R defaultValue) {
+		return ConfigLeafBuilder.create(this, name, type, defaultValue);
 	}
 
 	/**
@@ -351,7 +339,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	/**
 	 * Adds a {@code ConfigLeaf} bound to a {@link PropertyMirror}, using the mirror's type information.
 	 *
-	 * <p> This method behaves as if:
+	 * <p>This method behaves as if:
 	 * <pre>{@code this.beginValue(name, mirror.getMirroredType(), defaultValue).finishValue(mirror::mirror)}</pre>
 	 *
 	 * <p><strong>The built leaf will only accept values of the {@code mirror}'s
@@ -360,7 +348,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	 * to a valid serialized form. The mirror can be used to interact seamlessly
 	 * with the leaf using runtime types.
 	 *
-	 * <p> This method allows only basic configuration of the created leaf.
+	 * <p>This method allows only basic configuration of the created leaf.
 	 * For more flexibility, {@link #beginValue} can be used.
 	 *
 	 * @param name         the name of the child leaf
@@ -371,7 +359,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	 * @see #beginValue(String, SerializableType, Object)
 	 * @see ConfigTypes
 	 */
-	public <R> ConfigTreeBuilder withMirroredValue(@Nonnull String name, @Nonnull PropertyMirror<R> mirror, @Nullable R defaultValue) {
+	public <R> ConfigTreeBuilder withMirroredValue(@Nonnull String name, @Nonnull PropertyMirror<R> mirror, @Nonnull R defaultValue) {
 		this.beginValue(name, mirror.getMirroredType(), defaultValue).finishValue(mirror::mirror);
 		return this;
 	}

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/EnumSerializableType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/EnumSerializableType.java
@@ -19,6 +19,7 @@ public final class EnumSerializableType extends SerializableType<String> {
 
 	public EnumSerializableType(Set<String> validValues) {
 		super(String.class, EnumConstraintChecker.instance());
+		validValues.forEach(Objects::requireNonNull);
 		this.validValues = Collections.unmodifiableSet(new HashSet<>(validValues));
 	}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/RecordSerializableType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/RecordSerializableType.java
@@ -14,6 +14,7 @@ public final class RecordSerializableType extends SerializableType<ConfigBranch>
 
 	public RecordSerializableType(Map<String, SerializableType<?>> fields) {
 		super(ConfigBranch.class, RecordConstraintChecker.instance());
+		fields.keySet().forEach(Objects::requireNonNull);
 		this.fields = fields;
 	}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/SerializableType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/SerializableType.java
@@ -1,6 +1,7 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.schema.type;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.serialization.TypeSerializer;
@@ -67,7 +68,7 @@ public abstract class SerializableType<T> {
 	}
 
 	public final TypeCheckResult<T> test(T serializedValue) {
-		return this.checker.test(this, serializedValue);
+		return this.checker.test(this, Objects.requireNonNull(serializedValue));
 	}
 
 	public abstract <S> void serialize(TypeSerializer<S> serializer, S target);

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigType.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigType.java
@@ -2,6 +2,7 @@ package io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
 
@@ -88,7 +89,7 @@ public abstract class ConfigType<R, S, T extends SerializableType<S>> {
 	 * @see #toSerializedType(Object)
 	 */
 	public S toPlatformType(R runtimeValue) {
-		return this.serializer.apply(runtimeValue);
+		return this.serializer.apply(Objects.requireNonNull(runtimeValue));
 	}
 
 	/**
@@ -103,7 +104,7 @@ public abstract class ConfigType<R, S, T extends SerializableType<S>> {
 			throw new FiberConversionException("Invalid serialized value " + serializedValue);
 		}
 
-		return this.deserializer.apply(serializedValue);
+		return Objects.requireNonNull(this.deserializer.apply(serializedValue));
 	}
 
 	public Class<R> getRuntimeType() {

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/ConfigAttribute.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/ConfigAttribute.java
@@ -1,16 +1,18 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.tree;
 
+import javax.annotation.Nonnull;
+
 import io.github.fablabsmc.fablabs.api.fiber.v1.FiberId;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.SerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
 import io.github.fablabsmc.fablabs.impl.fiber.tree.ConfigAttributeImpl;
 
 public interface ConfigAttribute<T> extends Property<T> {
-	static <R, A> ConfigAttribute<A> create(FiberId id, ConfigType<R, A, ?> type, R defaultValue) {
+	static <R, A> ConfigAttribute<A> create(FiberId id, ConfigType<R, A, ?> type, @Nonnull R defaultValue) {
 		return create(id, type.getSerializedType(), type.toSerializedType(defaultValue));
 	}
 
-	static <A> ConfigAttribute<A> create(FiberId id, SerializableType<A> type, A defaultValue) {
+	static <A> ConfigAttribute<A> create(FiberId id, SerializableType<A> type, @Nonnull A defaultValue) {
 		return new ConfigAttributeImpl<>(id, type, defaultValue);
 	}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/ConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/ConfigLeaf.java
@@ -32,7 +32,7 @@ public interface ConfigLeaf<T> extends ConfigNode, Property<T>, Commentable {
 	 * @see ConfigLeaf#accepts(Object)
 	 */
 	@Override
-	boolean setValue(T value);
+	boolean setValue(@Nonnull T value);
 
 	/**
 	 * Returns {@code true} if this property can be set to the given raw value.
@@ -45,7 +45,7 @@ public interface ConfigLeaf<T> extends ConfigNode, Property<T>, Commentable {
 	 * @return {@code true} if this property accepts the given value, {@code false} otherwise.
 	 * @see SerializableType#accepts(Object)
 	 */
-	default boolean accepts(T rawValue) {
+	default boolean accepts(@Nonnull T rawValue) {
 		return true;
 	}
 
@@ -57,6 +57,7 @@ public interface ConfigLeaf<T> extends ConfigNode, Property<T>, Commentable {
 	 *
 	 * @return this node's value
 	 */
+	@Nonnull
 	@Override
 	T getValue();
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/HasValue.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/HasValue.java
@@ -1,5 +1,7 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.tree;
 
+import javax.annotation.Nonnull;
+
 /**
  * Indicates that this class holds some nullable value.
  *
@@ -11,6 +13,7 @@ public interface HasValue<T> {
 	 *
 	 * @return the value
 	 */
+	@Nonnull
 	T getValue();
 
 	/**

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/Property.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/tree/Property.java
@@ -1,5 +1,7 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.tree;
 
+import javax.annotation.Nonnull;
+
 /**
  * Implementing this interface means that this class has a nullable value
  * which can be mutated using the {@link Property#setValue(Object) setValue} method.
@@ -19,7 +21,7 @@ public interface Property<T> extends HasValue<T> {
 	 * @return {@code true} if this property changed as a result of the call
 	 * @see #accepts(Object)
 	 */
-	boolean setValue(T value);
+	boolean setValue(@Nonnull T value);
 
 	/**
 	 * Returns {@code true} if this property can be set to the given value.
@@ -28,7 +30,7 @@ public interface Property<T> extends HasValue<T> {
 	 * @return {@code true} if this property accepts the given value, {@code false} otherwise.
 	 * @see #setValue(Object)
 	 */
-	default boolean accepts(T value) {
+	default boolean accepts(@Nonnull T value) {
 		return true;
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -458,6 +458,10 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 		try {
 			value = (T) field.get(pojo);
+
+			if (value == null) {
+				throw new MalformedFieldException("Default value for field '" + field.getName() + "' is null");
+			}
 		} catch (IllegalAccessException e) {
 			throw new FiberException("Couldn't get value for field '" + field.getName() + "'", e);
 		}

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigAttributeImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigAttributeImpl.java
@@ -1,5 +1,7 @@
 package io.github.fablabsmc.fablabs.impl.fiber.tree;
 
+import java.util.Objects;
+
 import io.github.fablabsmc.fablabs.api.fiber.v1.FiberId;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.SerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigAttribute;
@@ -12,12 +14,12 @@ public class ConfigAttributeImpl<T> implements ConfigAttribute<T> {
 	public ConfigAttributeImpl(FiberId identifier, SerializableType<T> type, T value) {
 		this.identifier = identifier;
 		this.type = type;
-		this.value = value;
+		this.value = Objects.requireNonNull(value);
 	}
 
 	@Override
 	public boolean setValue(T value) {
-		this.value = value;
+		this.value = Objects.requireNonNull(value);
 		return true;
 	}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigAttributeImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigAttributeImpl.java
@@ -2,6 +2,8 @@ package io.github.fablabsmc.fablabs.impl.fiber.tree;
 
 import java.util.Objects;
 
+import javax.annotation.Nonnull;
+
 import io.github.fablabsmc.fablabs.api.fiber.v1.FiberId;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.SerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigAttribute;
@@ -9,21 +11,23 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigAttribute;
 public class ConfigAttributeImpl<T> implements ConfigAttribute<T> {
 	private final FiberId identifier;
 	private final SerializableType<T> type;
+	@Nonnull
 	private T value;
 
-	public ConfigAttributeImpl(FiberId identifier, SerializableType<T> type, T value) {
+	public ConfigAttributeImpl(FiberId identifier, SerializableType<T> type, @Nonnull T value) {
 		this.identifier = identifier;
 		this.type = type;
 		this.value = Objects.requireNonNull(value);
 	}
 
 	@Override
-	public boolean setValue(T value) {
+	public boolean setValue(@Nonnull T value) {
 		this.value = Objects.requireNonNull(value);
 		return true;
 	}
 
 	@Override
+	@Nonnull
 	public T getValue() {
 		return this.value;
 	}

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigLeafImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigLeafImpl.java
@@ -1,5 +1,6 @@
 package io.github.fablabsmc.fablabs.impl.fiber.tree;
 
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nonnull;
@@ -11,9 +12,8 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.TypeCheckResult;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigLeaf;
 
 public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLeaf<T> {
-	@Nullable
 	private T value;
-	@Nullable
+	@Nonnull
 	private final T defaultValue;
 	@Nonnull
 	private BiConsumer<T, T> listener;
@@ -30,19 +30,16 @@ public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLea
 	 * @param listener     the consumer or listener for this item. When this item's value changes, the consumer will be called with the old value as first argument and the new value as second argument.
 	 * @see ConfigLeafBuilder
 	 */
-	public ConfigLeafImpl(@Nonnull String name, @Nonnull SerializableType<T> type, @Nullable String comment, @Nullable T defaultValue, @Nonnull BiConsumer<T, T> listener) {
+	public ConfigLeafImpl(@Nonnull String name, @Nonnull SerializableType<T> type, @Nullable String comment, @Nonnull T defaultValue, @Nonnull BiConsumer<T, T> listener) {
 		super(name, comment);
-		this.defaultValue = defaultValue;
+		this.defaultValue = Objects.requireNonNull(defaultValue);
 		this.listener = listener;
 		this.type = type;
-
-		if (defaultValue != null) {
-			this.setValue(defaultValue);
-		}
+		this.setValue(defaultValue);
 	}
 
 	@Override
-	@Nullable
+	@Nonnull
 	public T getValue() {
 		return this.value;
 	}
@@ -60,7 +57,7 @@ public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLea
 	}
 
 	@Override
-	public boolean setValue(@Nullable T value) {
+	public boolean setValue(@Nonnull T value) {
 		// ensure ClassCastException comes sooner than later
 		// maybe accept any Object and return false if not an instance?
 		T correctedValue;
@@ -77,7 +74,7 @@ public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLea
 		}
 
 		T oldValue = this.value;
-		this.value = correctedValue;
+		this.value = Objects.requireNonNull(correctedValue);
 		this.listener.accept(oldValue, this.value);
 		return true;
 	}
@@ -94,7 +91,7 @@ public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLea
 	}
 
 	@Override
-	@Nullable
+	@Nonnull
 	public T getDefaultValue() {
 		return defaultValue;
 	}

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigLeafImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/ConfigLeafImpl.java
@@ -50,7 +50,7 @@ public final class ConfigLeafImpl<T> extends ConfigNodeImpl implements ConfigLea
 	}
 
 	@Override
-	public boolean accepts(T value) {
+	public boolean accepts(@Nonnull T value) {
 		// ensure ClassCastException comes sooner than later
 		// maybe accept any Object and return false if not an instance?
 		return this.type.accepts(this.type.getPlatformType().cast(value));

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
@@ -2,6 +2,7 @@ package io.github.fablabsmc.fablabs.impl.fiber.tree;
 
 import java.util.Objects;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
@@ -54,17 +55,18 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 	}
 
 	@Override
-	public boolean setValue(R value) {
+	public boolean setValue(@Nonnull R value) {
 		if (this.delegate == null) throw new IllegalStateException("No delegate property set for this mirror");
 		return this.delegate.setValue(this.converter.toPlatformType(value));
 	}
 
 	@Override
-	public boolean accepts(R value) {
+	public boolean accepts(@Nonnull R value) {
 		if (this.delegate == null) throw new IllegalStateException("No delegate property set for this mirror");
 		return this.delegate.accepts(this.converter.toPlatformType(value));
 	}
 
+	@Nonnull
 	@Override
 	public R getValue() {
 		if (this.delegate == null) throw new IllegalStateException("No delegate property set for this mirror");

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/NodeOperationsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/NodeOperationsTest.java
@@ -45,11 +45,11 @@ public class NodeOperationsTest {
 	@Test
 	@DisplayName("Value -> Value")
 	void copyValue() {
-		ConfigLeaf<BigDecimal> valueOne = ConfigLeafBuilder.create(null, "A", ConfigTypes.INTEGER.getSerializedType())
-				.withDefaultValue(BigDecimal.TEN)
+		ConfigLeaf<BigDecimal> valueOne = ConfigLeafBuilder
+				.create(null, "A", ConfigTypes.INTEGER.getSerializedType(), BigDecimal.TEN)
 				.build();
-		ConfigLeaf<BigDecimal> valueTwo = ConfigLeafBuilder.create(null, "A", ConfigTypes.INTEGER.getSerializedType())
-				.withDefaultValue(BigDecimal.valueOf(20))
+		ConfigLeaf<BigDecimal> valueTwo = ConfigLeafBuilder
+				.create(null, "A", ConfigTypes.INTEGER.getSerializedType(), BigDecimal.valueOf(20))
 				.build();
 
 		NodeOperations.copyValue(valueOne, valueTwo);

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -246,6 +246,19 @@ class AnnotatedSettingsTest {
 		assertEquals(0, this.node.getItems().size(), "Node is empty");
 	}
 
+	@Test
+	@DisplayName("Null default value")
+	void testNullDefault() {
+		Object pojo = new NullDefaultPojo();
+		assertThrows(FiberException.class,
+				() -> this.annotatedSettings.applyToNode(this.node, pojo),
+				"Prohibit null default value");
+	}
+
+	private static class NullDefaultPojo {
+		private String a = null;
+	}
+
 	private static class FinalSettingPojo {
 		private final int a = 5;
 	}

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
@@ -68,8 +68,7 @@ class ConfigTypesTest {
 		ListConfigType<List<Integer>, BigDecimal> type = ConfigTypes.makeList(elementType).withMaxSize(3);
 		Assertions.assertEquals(elementType.getSerializedType(), type.getSerializedType().getElementType());
 		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder
-				.create(null, "", type)
-				.withDefaultValue(Collections.emptyList())
+				.create(null, "", type, Collections.emptyList())
 				.build();
 		PropertyMirror<List<Integer>> mirror = PropertyMirror.create(type);
 		mirror.mirror(config);

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/derived/ConfigTypesTest.java
@@ -67,7 +67,10 @@ class ConfigTypesTest {
 		NumberConfigType<Integer> elementType = ConfigTypes.INTEGER.withMinimum(3).withMaximum(10);
 		ListConfigType<List<Integer>, BigDecimal> type = ConfigTypes.makeList(elementType).withMaxSize(3);
 		Assertions.assertEquals(elementType.getSerializedType(), type.getSerializedType().getElementType());
-		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder.create(null, "", type).build();
+		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder
+				.create(null, "", type)
+				.withDefaultValue(Collections.emptyList())
+				.build();
 		PropertyMirror<List<Integer>> mirror = PropertyMirror.create(type);
 		mirror.mirror(config);
 

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonSerializerTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonSerializerTest.java
@@ -174,6 +174,7 @@ class JanksonSerializerTest {
 			final SomeObject so = new SomeObject(0, "foo");
 
 			@Override
+			// @Nonnull
 			public SomeObject getValue() {
 				return this.so;
 			}

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonSerializerTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonSerializerTest.java
@@ -33,8 +33,7 @@ class JanksonSerializerTest {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		JanksonSerializer jk = new JanksonSerializer();
 		ConfigTree nodeOne = ConfigTree.builder()
-				.beginValue("A", ConfigTypes.INTEGER.getSerializedType(), null)
-				.withDefaultValue(BigDecimal.TEN)
+				.beginValue("A", ConfigTypes.INTEGER.getSerializedType(), BigDecimal.TEN)
 				.finishValue()
 				.build();
 

--- a/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/builder/constraint/ConstraintsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/builder/constraint/ConstraintsTest.java
@@ -25,7 +25,10 @@ class ConstraintsTest {
 	public void testNumericalConstraints() {
 		NumberConfigType<Integer> type = ConfigTypes.INTEGER.withMinimum(5);
 
-		ConfigLeaf<BigDecimal> leaf = ConfigLeafBuilder.create(null, "", type.getSerializedType()).build();
+		ConfigLeaf<BigDecimal> leaf = ConfigLeafBuilder
+				.create(null, "", type.getSerializedType())
+				.withDefaultValue(BigDecimal.valueOf(5))
+				.build();
 
 		assertFalse(leaf.accepts(BigDecimal.valueOf(-2)), "Input can't be lower than 5");
 		assertFalse(leaf.accepts(BigDecimal.valueOf(4)), "Input can't be lower than 5");
@@ -40,7 +43,10 @@ class ConstraintsTest {
 		ListConfigType<Integer[], BigDecimal> type = ConfigTypes.makeArray(
 				ConfigTypes.INTEGER.withValidRange(3, 10, 1)
 		).withMaxSize(3).withMinSize(1);
-		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder.create(null, "foo", type).build();
+		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder
+				.create(null, "foo", type)
+				.withDefaultValue(new Integer[] { 3, 10 })
+				.build();
 		PropertyMirror<Integer[]> mirror = PropertyMirror.create(type);
 		mirror.mirror(config);
 

--- a/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/builder/constraint/ConstraintsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/builder/constraint/ConstraintsTest.java
@@ -26,8 +26,7 @@ class ConstraintsTest {
 		NumberConfigType<Integer> type = ConfigTypes.INTEGER.withMinimum(5);
 
 		ConfigLeaf<BigDecimal> leaf = ConfigLeafBuilder
-				.create(null, "", type.getSerializedType())
-				.withDefaultValue(BigDecimal.valueOf(5))
+				.create(null, "", type.getSerializedType(), BigDecimal.valueOf(5))
 				.build();
 
 		assertFalse(leaf.accepts(BigDecimal.valueOf(-2)), "Input can't be lower than 5");
@@ -44,8 +43,7 @@ class ConstraintsTest {
 				ConfigTypes.INTEGER.withValidRange(3, 10, 1)
 		).withMaxSize(3).withMinSize(1);
 		ConfigLeaf<List<BigDecimal>> config = ConfigLeafBuilder
-				.create(null, "foo", type)
-				.withDefaultValue(new Integer[] { 3, 10 })
+				.create(null, "foo", type, new Integer[] { 3, 10 })
 				.build();
 		PropertyMirror<Integer[]> mirror = PropertyMirror.create(type);
 		mirror.mirror(config);


### PR DESCRIPTION
Attempting to set `null` to config values in constraints, default values, or values in config trees will throw `NullPointerException`. Attempting to deserialize a `null` default value in an annotated POJO will throw `MalformedFieldException`.