### PR TITLE
Allow AnnotatedSettings to instantiate null groups

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -344,15 +344,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		try {
 			// Inner classes have an extra parameter in their constructor: a reference to the 'upper class'.
 			boolean isInner = !Modifier.isStatic(clazz.getModifiers());
-
-			if (isInner) {
-				constructor = Arrays.stream(clazz.getDeclaredConstructors())
-						.filter(c -> c.getParameterCount() == 1)
-						.findAny()
-						.orElseThrow(() -> new FiberException("Couldn't create group from inner class " + clazz.getSimpleName() + ", is the class public and does it have a nullary constructor?"));
-			} else { // static nested class
-				constructor = clazz.getDeclaredConstructor();
-			}
+			constructor = isInner ? clazz.getDeclaredConstructor(clazz.getDeclaringClass()) : clazz.getDeclaredConstructor();
 
 			accessible = constructor.isAccessible();
 			constructor.setAccessible(true);

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -1,13 +1,5 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.annotation;
 
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.BiConsumer;
-
 import io.github.fablabsmc.fablabs.api.fiber.v1.exception.FiberException;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.ListSerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.StringSerializableType;
@@ -21,6 +13,14 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.PropertyMirror;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -152,29 +152,29 @@ class AnnotatedSettingsTest {
 		Property<List<String>> value1 = this.node.lookupLeaf("nonEmptyArrayShortStrings", type.getSerializedType());
 		assertNotNull(value1, "Setting exists");
 		mirror1.mirror(value1);
-		assertTrue(mirror1.setValue(new String[] {"ab", "", "ba", ""}));
+		assertTrue(mirror1.setValue(new String[]{"ab", "", "ba", ""}));
 		assertFalse(mirror1.setValue(new String[0]), "Empty array");
-		assertFalse(mirror1.setValue(new String[] {"aaaaaaaaaaaa"}), "Strings too long");
+		assertFalse(mirror1.setValue(new String[]{"aaaaaaaaaaaa"}), "Strings too long");
 		ListConfigType<int[], BigDecimal> type2 = ConfigTypes.makeIntArray(ConfigTypes.INTEGER);
 		PropertyMirror<int[]> mirror2 = PropertyMirror.create(type2);
 		this.node.lookupAndBind("numbers", mirror2);
 		assertNotNull(mirror2, "Setting exists");
-		assertTrue(mirror2.setValue(new int[] {3, 4, 5}));
-		assertArrayEquals(new int[] {3, 4, 5}, mirror2.getValue());
+		assertTrue(mirror2.setValue(new int[]{3, 4, 5}));
+		assertArrayEquals(new int[]{3, 4, 5}, mirror2.getValue());
 		assertTrue(mirror2.setValue(new int[0]));
 		assertArrayEquals(new int[0], mirror2.getValue(), "Value should not change after unrecoverable setValue");
-		assertFalse(mirror2.accepts(new int[] {1, 2, 3, 4, 5, 6, 7}), "Too many elements");
-		assertTrue(mirror2.setValue(new int[] {1, 2, 3, 4, 5, 6, 7}), "Recoverable length issue");
-		assertArrayEquals(new int[] {1, 2, 3}, mirror2.getValue(), "Value not properly trimmed");
-		assertFalse(mirror2.accepts(new int[] {1, 11, 3, 4, 5, 6, 7}), "Too many elements and element out of range");
-		assertTrue(mirror2.setValue(new int[] {1, 11, 3, 4, 5, 6, 7}), "Recoverable length issue");
-		assertArrayEquals(new int[] {1, 10, 3}, mirror2.getValue(), "Value not properly trimmed or corrected");
-		assertFalse(mirror2.accepts(new int[] {-1, 0, 1}), "Negative number not allowed");
-		assertTrue(mirror2.setValue(new int[] {-1, 0, 1}), "Correction for out of bounds numbers available");
-		assertArrayEquals(new int[] {0, 0, 1}, mirror2.getValue(), "Negative number should be brought back into range");
-		assertFalse(mirror2.accepts(new int[] {9, 10, 11}), "Numbers above 10 not allowed");
-		assertTrue(mirror2.setValue(new int[] {9, 10, 11}), "Correction for out of bounds numbers available");
-		assertArrayEquals(new int[] {9, 10, 10}, mirror2.getValue(), ">10 number should be brought back into range");
+		assertFalse(mirror2.accepts(new int[]{1, 2, 3, 4, 5, 6, 7}), "Too many elements");
+		assertTrue(mirror2.setValue(new int[]{1, 2, 3, 4, 5, 6, 7}), "Recoverable length issue");
+		assertArrayEquals(new int[]{1, 2, 3}, mirror2.getValue(), "Value not properly trimmed");
+		assertFalse(mirror2.accepts(new int[]{1, 11, 3, 4, 5, 6, 7}), "Too many elements and element out of range");
+		assertTrue(mirror2.setValue(new int[]{1, 11, 3, 4, 5, 6, 7}), "Recoverable length issue");
+		assertArrayEquals(new int[]{1, 10, 3}, mirror2.getValue(), "Value not properly trimmed or corrected");
+		assertFalse(mirror2.accepts(new int[]{-1, 0, 1}), "Negative number not allowed");
+		assertTrue(mirror2.setValue(new int[]{-1, 0, 1}), "Correction for out of bounds numbers available");
+		assertArrayEquals(new int[]{0, 0, 1}, mirror2.getValue(), "Negative number should be brought back into range");
+		assertFalse(mirror2.accepts(new int[]{9, 10, 11}), "Numbers above 10 not allowed");
+		assertTrue(mirror2.setValue(new int[]{9, 10, 11}), "Correction for out of bounds numbers available");
+		assertArrayEquals(new int[]{9, 10, 10}, mirror2.getValue(), ">10 number should be brought back into range");
 		Property<List<String>> value3 = this.node.lookupLeaf("shortArrayIdStrings", new ListSerializableType<>(StringSerializableType.DEFAULT_STRING));
 		assertNotNull(value3, "Setting exists");
 		assertTrue(value3.accepts(Arrays.asList("a:b", "fabric:test")));
@@ -355,7 +355,7 @@ class AnnotatedSettingsTest {
 		public SubNode nullNode;
 
 		@SuppressWarnings("InnerClassMayBeStatic")
-		// we want to test this edge case
+				// we want to test this edge case
 		class SubNode {
 			private int c = 5;
 		}

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -1,12 +1,5 @@
 package io.github.fablabsmc.fablabs.api.fiber.v1.annotation;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +21,8 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.PropertyMirror;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 // TODO add tests for user-defined types and processors
 @SuppressWarnings({"unused", "FieldMayBeFinal"})
@@ -221,13 +216,19 @@ class AnnotatedSettingsTest {
 
 	@Test
 	@DisplayName("Subnodes")
-	void testSubNodes() throws FiberException {
+	void testSubNodes() {
 		SubNodePojo pojo = new SubNodePojo();
-		this.annotatedSettings.applyToNode(this.node, pojo);
-		assertEquals(1, this.node.getItems().size(), "Node has one item");
+		assertDoesNotThrow(() -> this.annotatedSettings.applyToNode(this.node, pojo), "Applied node successfully");
+		assertEquals(2, this.node.getItems().size(), "Node has two items");
+
 		ConfigTree subnode = (ConfigTree) this.node.lookup("a");
-		assertNotNull(subnode, "Subnode exists");
-		assertEquals(1, subnode.getItems().size(), "Subnode has one item");
+		assertNotNull(subnode, "First subnode exists");
+		assertEquals(1, subnode.getItems().size(), "First subnode has one item");
+
+		assertNotNull(pojo.nullNode, "Second subnode received instance");
+		ConfigTree subnode2 = (ConfigTree) this.node.lookup("b");
+		assertNotNull(subnode, "Second subnode exists");
+		assertEquals(1, subnode.getItems().size(), "Second subnode has one item");
 	}
 
 	@Test
@@ -350,10 +351,13 @@ class AnnotatedSettingsTest {
 		@Setting.Group(name = "a")
 		public SubNode node = new SubNode();
 
+		@Setting.Group(name = "b")
+		public SubNode nullNode;
+
 		@SuppressWarnings("InnerClassMayBeStatic")
 		// we want to test this edge case
 		class SubNode {
-			private int b = 5;
+			private int c = 5;
 		}
 	}
 }


### PR DESCRIPTION
This PR allows `AnnotatedSettings` to instantiate subgroups, if needed:

Previously, the following would cause an NPE:
```java
static class Config {
    @Setting.Group
    private SubConfig sub; // Users have to supply an instance here
    
    public static class SubConfig {
        int a = 5;
    }
}
```

This PR attempts to create an instance of `SubConfig` (when `sub` is null), and if it succeeds, sets `sub` to this new instance.