### PR TITLE
Fix decimal increment comprehension check being too lenient

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/constraint/DecimalConstraintChecker.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/constraint/DecimalConstraintChecker.java
@@ -37,9 +37,18 @@ public final class DecimalConstraintChecker extends ConstraintChecker<BigDecimal
 
 	@Override
 	public boolean comprehends(DecimalSerializableType cfg, DecimalSerializableType cfg2) {
-		return (cfg.getMinimum() == null || cfg2.getMinimum() != null && cfg.getMinimum().compareTo(cfg2.getMinimum()) <= 0)
-				&& (cfg.getMaximum() == null || cfg2.getMaximum() != null && cfg.getMaximum().compareTo(cfg2.getMaximum()) >= 0)
-				&& (cfg.getIncrement() == null || cfg2.getIncrement() != null && cfg2.getIncrement().remainder(cfg.getIncrement()).intValue() == 0);
+		if (cfg.getMinimum() == null || cfg2.getMinimum() != null && cfg.getMinimum().compareTo(cfg2.getMinimum()) <= 0) {
+			if (cfg.getMaximum() == null || cfg2.getMaximum() != null && cfg.getMaximum().compareTo(cfg2.getMaximum()) >= 0) {
+				if (cfg.getIncrement() == null) {
+					return true;
+				} else if (cfg2.getIncrement() != null) {
+					BigDecimal remainder = cfg2.getIncrement().remainder(cfg.getIncrement());
+					return remainder.equals(BigDecimal.ZERO.setScale(remainder.scale(), BigDecimal.ROUND_UNNECESSARY));
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private static BigDecimal nearest(BigDecimal less, BigDecimal value, BigDecimal more) {

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/constraint/DecimalConstraintChecker.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/constraint/DecimalConstraintChecker.java
@@ -39,12 +39,7 @@ public final class DecimalConstraintChecker extends ConstraintChecker<BigDecimal
 	public boolean comprehends(DecimalSerializableType cfg, DecimalSerializableType cfg2) {
 		if (cfg.getMinimum() == null || cfg2.getMinimum() != null && cfg.getMinimum().compareTo(cfg2.getMinimum()) <= 0) {
 			if (cfg.getMaximum() == null || cfg2.getMaximum() != null && cfg.getMaximum().compareTo(cfg2.getMaximum()) >= 0) {
-				if (cfg.getIncrement() == null) {
-					return true;
-				} else if (cfg2.getIncrement() != null) {
-					BigDecimal remainder = cfg2.getIncrement().remainder(cfg.getIncrement());
-					return remainder.equals(BigDecimal.ZERO.setScale(remainder.scale(), BigDecimal.ROUND_UNNECESSARY));
-				}
+				return cfg.getIncrement() == null || cfg2.getIncrement() != null && cfg2.getIncrement().remainder(cfg.getIncrement()).compareTo(BigDecimal.ZERO) == 0;
 			}
 		}
 

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/SerializableTypesTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/schema/type/SerializableTypesTest.java
@@ -1,0 +1,49 @@
+package io.github.fablabsmc.fablabs.api.fiber.v1.schema.type;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SerializableTypesTest {
+	@DisplayName("Test decimal type comprehension")
+	@Test
+	void testDecimalType() {
+		DecimalSerializableType typeA = new DecimalSerializableType(BigDecimal.TEN.negate(), null, null);
+		DecimalSerializableType typeB = new DecimalSerializableType(null, BigDecimal.TEN, null);
+		assertFalse(typeA.isAssignableFrom(typeB));
+		assertFalse(typeB.isAssignableFrom(typeA));
+		DecimalSerializableType typeC = new DecimalSerializableType(BigDecimal.TEN.negate(), BigDecimal.TEN, null);
+		assertTrue(typeA.isAssignableFrom(typeC));
+		assertTrue(typeB.isAssignableFrom(typeC));
+		assertFalse(typeC.isAssignableFrom(typeA));
+		assertFalse(typeC.isAssignableFrom(typeB));
+		assertThrows(IllegalStateException.class, () -> new DecimalSerializableType(null, null, BigDecimal.ONE));
+		DecimalSerializableType typeD = new DecimalSerializableType(BigDecimal.TEN.negate(), BigDecimal.TEN, BigDecimal.ONE);
+		assertTrue(typeA.isAssignableFrom(typeD));
+		assertTrue(typeB.isAssignableFrom(typeD));
+		assertTrue(typeC.isAssignableFrom(typeD));
+		assertFalse(typeD.isAssignableFrom(typeA));
+		assertFalse(typeD.isAssignableFrom(typeB));
+		assertFalse(typeD.isAssignableFrom(typeC));
+		DecimalSerializableType typeE = new DecimalSerializableType(BigDecimal.ONE.negate(), BigDecimal.ONE, BigDecimal.valueOf(0.5));
+		assertTrue(typeA.isAssignableFrom(typeE));
+		assertTrue(typeB.isAssignableFrom(typeE));
+		assertTrue(typeC.isAssignableFrom(typeE));
+		assertFalse(typeD.isAssignableFrom(typeE));
+		assertFalse(typeE.isAssignableFrom(typeA));
+		assertFalse(typeE.isAssignableFrom(typeB));
+		assertFalse(typeE.isAssignableFrom(typeC));
+		assertFalse(typeE.isAssignableFrom(typeD));
+		DecimalSerializableType typeF = new DecimalSerializableType(BigDecimal.ONE.negate(), BigDecimal.ONE, BigDecimal.ONE);
+		assertTrue(typeE.isAssignableFrom(typeF));
+		assertFalse(typeF.isAssignableFrom(typeE));
+		DecimalSerializableType typeG = new DecimalSerializableType(BigDecimal.ONE.negate(), BigDecimal.ONE, BigDecimal.ONE.setScale(100, BigDecimal.ROUND_UNNECESSARY));
+		assertTrue(typeF.isAssignableFrom(typeG));
+		assertTrue(typeG.isAssignableFrom(typeF));
+	}
+}


### PR DESCRIPTION
Currently, a number with a fractional increment (ie. a float) is considered assignable to a number with an integral increment. This causes very well hidden bugs, and should be fixed quickly.

TODO: 
- [x] add a test