### PR TITLE
Fix 0.22.0 build

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/BranchAnnotationProcessor.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/BranchAnnotationProcessor.java
@@ -19,7 +19,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
  * specifically target {@link ElementType#FIELD}.
  *
  * @param <A> the type of annotations processed
- * @see AnnotatedSettings#registerGroupProcessor(Class, BranchAnnotationProcessor)
+ * @see AnnotatedSettings.Builder#registerGroupProcessor(Class, BranchAnnotationProcessor)
  */
 @FunctionalInterface
 public interface BranchAnnotationProcessor<A extends Annotation> extends ConfigAnnotationProcessor<A, Field, ConfigTreeBuilder> {

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/ConstraintAnnotationProcessor.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/ConstraintAnnotationProcessor.java
@@ -21,7 +21,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
  * specifically target {@link ElementType#TYPE_USE}.
  *
  * @param <A> the type of annotations processed
- * @see AnnotatedSettings#registerConstraintProcessor(Class, ConstraintAnnotationProcessor)
+ * @see AnnotatedSettings.Builder#registerConstraintProcessor(Class, ConstraintAnnotationProcessor)
  */
 public interface ConstraintAnnotationProcessor<A extends Annotation> {
 	/**

--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/LeafAnnotationProcessor.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/processor/LeafAnnotationProcessor.java
@@ -16,7 +16,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
  * specifically target {@link ElementType#FIELD}.
  *
  * @param <A> the type of annotations processed
- * @see AnnotatedSettings#registerSettingProcessor(Class, LeafAnnotationProcessor)
+ * @see AnnotatedSettings.Builder#registerSettingProcessor(Class, LeafAnnotationProcessor)
  */
 @FunctionalInterface
 public interface LeafAnnotationProcessor<A extends Annotation> extends ConfigAnnotationProcessor<A, Field, ConfigLeafBuilder<?, ?>> {

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonValueSerializerTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/serialization/JanksonValueSerializerTest.java
@@ -184,7 +184,7 @@ class JanksonValueSerializerTest {
 		FiberSerialization.deserialize(nodeTwo, new ByteArrayInputStream(bos.toByteArray()), jk);
 		assertEquals("1.0.0", versionTwo.getValue(), "RegEx constraint bypassed");
 		assertEquals(20, settingTwo.getValue(), "Range constraint bypassed");
-		assertEquals("{ \"child\": { \"A\": 30 }, \"version\": \"0.1\" }", bos.toString("UTF-8"));
+		assertEquals("{ \"version\": \"0.1\", \"child\": { \"A\": 30 } }", bos.toString("UTF-8"));
 
 		bos.reset();
 
@@ -194,7 +194,7 @@ class JanksonValueSerializerTest {
 		FiberSerialization.deserialize(nodeTwo, new ByteArrayInputStream(bos.toByteArray()), jk);
 		assertEquals("0.1.0", versionTwo.getValue(), "Valid value rejected");
 		assertEquals(-5, settingTwo.getValue(), "Valid value rejected");
-		assertEquals("{ \"child\": { \"A\": -5 }, \"version\": \"0.1.0\" }", bos.toString("UTF-8"));
+		assertEquals("{ \"version\": \"0.1.0\", \"child\": { \"A\": -5 } }", bos.toString("UTF-8"));
 	}
 
 	@Test


### PR DESCRIPTION
Should've checked 0.22.0 more thoroughly. Oops.

Fixed javadoc references and the ordering in the jankson serializer test. No version bump because no functional changes were made.