### PR TITLE
Always perform runtime type conversion with passive invalidation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 major = 0
 minor = 22
-patch = 0
+patch = 1

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImpl.java
@@ -74,7 +74,7 @@ public final class PropertyMirrorImpl<R, S> implements PropertyMirror<R> {
 		if (this.cachedValue == null || this.lastSerializedValue != null) {
 			S serializedValue = this.delegate.getValue();
 
-			if (!Objects.equals(this.lastSerializedValue, serializedValue)) {
+			if (cachedValue == null || !Objects.equals(this.lastSerializedValue, serializedValue)) {
 				this.cachedValue = this.mirroredType.toRuntimeType(serializedValue);
 				this.lastSerializedValue = serializedValue;
 			}

--- a/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImplTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/impl/fiber/tree/PropertyMirrorImplTest.java
@@ -1,0 +1,57 @@
+package io.github.fablabsmc.fablabs.impl.fiber.tree;
+
+import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigTypes;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigAttribute;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.PropertyMirror;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PropertyMirrorImplTest {
+
+	// see https://github.com/FabLabsMC/fiber/issues/63
+	@Test
+	@DisplayName("Passively invalidated values are correct")
+	public void testPassiveInvalidation() {
+		PropertyMirror<Boolean> mirror = PropertyMirror.create(ConfigTypes.BOOLEAN);
+		ConfigTree.builder()
+				.beginValue("mirrored", ConfigTypes.BOOLEAN, false)
+				.finishValue(mirror::mirror)
+				.build();
+
+		assertFalse(mirror.getValue());
+
+		assertTrue(mirror.setValue(true));
+		assertTrue(mirror.getValue());
+
+		assertTrue(mirror.setValue(true));
+		assertTrue(mirror.getValue());
+
+		assertTrue(mirror.setValue(false));
+		assertFalse(mirror.getValue());
+	}
+
+	@Test
+	@DisplayName("Actively invalidated values are correct")
+	public void testActiveInvalidation() {
+		// Attributes aren't ConfigLeafs, so they will use active invalidation.
+		ConfigAttribute<Boolean> attribute = ConfigAttribute.create(null, ConfigTypes.BOOLEAN, false);
+		PropertyMirror<Boolean> mirror = PropertyMirror.create(ConfigTypes.BOOLEAN);
+		mirror.mirror(attribute);
+
+		assertFalse(mirror.getValue());
+
+		assertTrue(mirror.setValue(true));
+		assertTrue(mirror.getValue());
+
+		assertTrue(mirror.setValue(true));
+		assertTrue(mirror.getValue());
+
+		assertTrue(mirror.setValue(false));
+		assertFalse(mirror.getValue());
+	}
+
+}


### PR DESCRIPTION
Closes #63 

Passively invalidated (mirrored) values wouldn't actually receive a new `cachedValue` after invalidation.
This PR also adds a test for this and bumps version to `0.22.1`.