### PR TITLE
Improve group errors from AnnotatedSettings

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/exception/ProcessingMemberException.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/exception/ProcessingMemberException.java
@@ -3,10 +3,19 @@ package io.github.fablabsmc.fablabs.api.fiber.v1.exception;
 import java.lang.reflect.Member;
 
 public class ProcessingMemberException extends FiberException {
-	final Member member;
+	private final Member member;
+
+	public ProcessingMemberException(String message, Member member) {
+		super(message);
+		this.member = member;
+	}
 
 	public ProcessingMemberException(String message, Throwable cause, Member member) {
 		super(message, cause);
 		this.member = member;
+	}
+
+	public Member getMember() {
+		return this.member;
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -131,9 +131,11 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 				ConfigTreeBuilder sub = this.builder.fork(name);
 				group.setAccessible(true);
 				Object subPojo = group.get(pojo);
+
 				if (subPojo == null) {
 					throw new ProcessingMemberException("Group " + name + " is null. Did you forget to initialize it?", group);
 				}
+
 				AnnotatedSettingsImpl.this.applyToNode(sub, subPojo);
 				this.applyAnnotationProcessors(pojo, group, sub, AnnotatedSettingsImpl.this.groupSettingProcessors);
 				sub.build();

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -127,7 +127,6 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		@Override
 		public void processGroup(Object pojo, Field group) throws ProcessingMemberException {
 			try {
-				checkViolation(group);
 				String name = this.findName(group);
 				ConfigTreeBuilder sub = this.builder.fork(name);
 				group.setAccessible(true);

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -130,7 +130,11 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 				String name = this.findName(group);
 				ConfigTreeBuilder sub = this.builder.fork(name);
 				group.setAccessible(true);
-				AnnotatedSettingsImpl.this.applyToNode(sub, group.get(pojo));
+				Object subPojo = group.get(pojo);
+				if (subPojo == null) {
+					throw new ProcessingMemberException("Group " + name + " is null. Did you forget to initialize it?", group);
+				}
+				AnnotatedSettingsImpl.this.applyToNode(sub, subPojo);
 				this.applyAnnotationProcessors(pojo, group, sub, AnnotatedSettingsImpl.this.groupSettingProcessors);
 				sub.build();
 			} catch (FiberException | IllegalAccessException e) {


### PR DESCRIPTION
This PR replaces the obtuse NPE when forgetting to initialize a group in a POJO with a clearer `ProcessingMemberException`.

It also removes the restriction that groups cannot be final, as I am pretty sure we only mutate group instances, never the field.