### PR TITLE
Fix invalid javadoc tags

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigTreeBuilder.java
@@ -98,7 +98,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	@Nullable
 	@Override
@@ -109,7 +109,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	@SuppressWarnings("unchecked")
 	@Nullable
@@ -125,7 +125,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	@Override
 	public boolean lookupAndBind(String name, PropertyMirror<?> mirror) {
@@ -199,7 +199,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	@Override
 	public ConfigTreeBuilder withAttributes(Collection<ConfigAttribute<?>> attributes) {
@@ -208,7 +208,7 @@ public class ConfigTreeBuilder extends ConfigNodeBuilder implements ConfigTree {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	@Override
 	public ConfigTreeBuilder withAttribute(ConfigAttribute<?> attribute) {


### PR DESCRIPTION
This PR should fix the invalid `inheritJavadoc` tag use introduced in Fiber 0.23.0.
Closes #71 