### PR TITLE
Fix maven publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     `java-library`
     `maven-publish`
-    id("com.github.johnrengelman.shadow") version "5.0.0"
+    id("com.github.johnrengelman.shadow") version "5.2.0"
     id("moe.nikky.persistentCounter") version "0.0.8-SNAPSHOT"
     id("checkstyle")
 }
@@ -87,22 +87,16 @@ val processResources = tasks.getByName<ProcessResources>("processResources") {
 publishing {
     publications {
         val main = create("main", MavenPublication::class.java) {
-            artifact(shadowJar) {
-                classifier = "" // why do i need this GRADLE ?
-            }
+            artifact(shadowJar)
             artifact(sourcesJar)
             artifact(javadocJar)
-            project.shadow.component(this)
         }
         if(isCI) {
             create("snapshot", MavenPublication::class.java) {
                 version = "$major.$minor.$patch-SNAPSHOT"
-                artifact(shadowJar) {
-                    classifier = "" // why do i need this GRADLE ?
-                }
+                artifact(shadowJar)
                 artifact(sourcesJar)
                 artifact(javadocJar)
-                project.shadow.component(this)
             }
         }
     }


### PR DESCRIPTION
Should fix #74.
It appears that the build error is caused by a duplicated publication, with `artifact(shadowJar)` and `project.shadow.component(this)` performing the same operation.
Given the comment left in the publishing block of the builscript, I assume that was a kludge that stopped working. Running `publishToMavenLocal` seems to work after simplifying the buildscript.
Would like @NikkyAI's opinion.