### PR TITLE
Allow setting group comments using annotations

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/Setting.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/Setting.java
@@ -70,6 +70,15 @@ public @interface Setting {
 		 * @return An empty string ({@code ""}) if no custom name was set, or the custom name if one was set.
 		 */
 		String name() default "";
+
+		/**
+		 * Sets the comment that will be used for this setting group.
+		 *
+		 * <p>If empty, no comment will be set.
+		 *
+		 * @return An empty string ({@code ""}) if no comment was set, or the comment if one was set.
+		 */
+		String comment() default "";
 	}
 
 	@Target({})

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -21,6 +21,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.ListSerializableType
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.StringSerializableType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigTypes;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ListConfigType;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigBranch;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigLeaf;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigNode;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
@@ -226,9 +227,10 @@ class AnnotatedSettingsTest {
 		SubNodePojo pojo = new SubNodePojo();
 		this.annotatedSettings.applyToNode(this.node, pojo);
 		assertEquals(1, this.node.getItems().size(), "Node has one item");
-		ConfigTree subnode = (ConfigTree) this.node.lookup("a");
+		ConfigBranch subnode = this.node.lookupBranch("a");
 		assertNotNull(subnode, "Subnode exists");
 		assertEquals(1, subnode.getItems().size(), "Subnode has one item");
+		assertEquals("A subnode", subnode.getComment());
 	}
 
 	@Test
@@ -388,7 +390,7 @@ class AnnotatedSettingsTest {
 	}
 
 	private static class SubNodePojo {
-		@Setting.Group(name = "a")
+		@Setting.Group(name = "a", comment = "A subnode")
 		public SubNode node = new SubNode();
 
 		// we want to test this edge case


### PR DESCRIPTION
Setting a comment for a config group was already possible using the builder, but it seems we forgot to add that capability to annotation processing.