### PR TITLE
Bump version to 0.23.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 major = 0
-minor = 22
-patch = 1
+minor = 23
+patch = 0


### PR DESCRIPTION
#70 missed updating the version in gradle.properties, resulting in the update being published as `0.22.1-2`. This PR fixes this mistake.