### PR TITLE
Implement backed (and deferred) config leaves to pick up on POJO mutations

### DIFF
--- a/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigLeafBuilder.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/fiber/v1/builder/ConfigLeafBuilder.java
@@ -189,9 +189,6 @@ public class ConfigLeafBuilder<T, R> extends ConfigNodeBuilder {
 		built.getAttributes().putAll(this.attributes);
 
 		if (parent != null) {
-			// We don't know what kind of evil collection we're about to add a node to.
-			// Though, we don't really want to throw an exception on this method because no developer likes try-catching every setting they build.
-			// Let's tread with caution.
 			try {
 				parent.getItems().add(built);
 			} catch (RuntimeFiberException e) {

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -46,6 +46,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.exception.RuntimeFiberException;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
 import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigTypes;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigBranch;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigLeaf;
 import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigTree;
 import io.github.fablabsmc.fablabs.impl.fiber.annotation.magic.TypeMagic;
 
@@ -157,12 +158,16 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		private <R, S> void processSetting(Object pojo, Field setting, ConfigType<R, S, ?> type) throws FiberException {
 			String name = this.findName(setting);
 			List<Member> listeners = this.listenerMap.getOrDefault(name, Collections.emptyList());
-			ConfigLeafBuilder<S, R> leaf = this.builder
+			ConfigLeafBuilder<S, R> leafBuilder = this.builder
 					.beginValue(name, type, this.findDefaultValue(pojo, setting))
 					.withComment(this.findComment(setting))
 					.withListener(this.constructListener(pojo, setting, listeners, type));
-			this.applyAnnotationProcessors(pojo, setting, leaf, AnnotatedSettingsImpl.this.valueSettingProcessors);
-			leaf.build();
+			this.applyAnnotationProcessors(pojo, setting, leafBuilder, AnnotatedSettingsImpl.this.valueSettingProcessors);
+			ConfigLeaf<S> leaf = leafBuilder.build();
+			leaf.detach();
+			builder.getItems().remove(leaf);
+			BackedConfigLeaf<R, S> deferred = new BackedConfigLeaf<>(leaf, type, pojo, setting);
+			builder.getItems().add(deferred); // This will also attach deferred
 		}
 
 		@Nonnull

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -165,7 +165,6 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 					.withListener(this.constructListener(pojo, listeners, type));
 			this.applyAnnotationProcessors(pojo, setting, leafBuilder, AnnotatedSettingsImpl.this.valueSettingProcessors);
 			ConfigLeaf<S> leaf = leafBuilder.build();
-			leaf.detach();
 			builder.getItems().remove(leaf);
 			BackedConfigLeaf<R, S> deferred = new BackedConfigLeaf<>(leaf, type, pojo, setting);
 			builder.getItems().add(deferred); // This will also attach deferred

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/AnnotatedSettingsImpl.java
@@ -158,6 +158,7 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 		private <R, S> void processSetting(Object pojo, Field setting, ConfigType<R, S, ?> type) throws FiberException {
 			String name = this.findName(setting);
 			List<Member> listeners = this.listenerMap.getOrDefault(name, Collections.emptyList());
+			setting.setAccessible(true);
 			ConfigLeafBuilder<S, R> leafBuilder = this.builder
 					.beginValue(name, type, this.findDefaultValue(pojo, setting))
 					.withComment(this.findComment(setting))
@@ -315,8 +316,6 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 
 		@SuppressWarnings("unchecked")
 		private <T> T findDefaultValue(Object pojo, Field field) throws FiberException {
-			boolean accessible = field.isAccessible();
-			field.setAccessible(true);
 			T value;
 
 			try {
@@ -329,7 +328,6 @@ public final class AnnotatedSettingsImpl implements AnnotatedSettings {
 				throw new FiberException("Couldn't get value for field '" + field.getName() + "'", e);
 			}
 
-			field.setAccessible(accessible);
 			return value;
 		}
 

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
@@ -27,10 +27,10 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigLeaf;
  * @param <S>
  */
 public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
-	final ConfigLeaf<S> backing;
-	final ConfigType<R, S, ?> type;
-	final Object pojo;
-	final Field backingField;
+	private final ConfigLeaf<S> backing;
+	private final ConfigType<R, S, ?> type;
+	private final Object pojo;
+	private final Field backingField;
 	private R cachedValue = null;
 	private ConfigBranch parent;
 

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
@@ -106,7 +106,6 @@ public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
 	public boolean setValue(@Nonnull S value) {
 		if (this.backing.setValue(value)) {
 			try {
-				this.backingField.setAccessible(true);
 				value = backing.getValue(); // Might've changed after a type check + correction, so we fetch again
 				this.backingField.set(pojo, type.toRuntimeType(value));
 			} catch (IllegalAccessException e) {
@@ -124,7 +123,6 @@ public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
 	@SuppressWarnings("unchecked")
 	public S getValue() {
 		try {
-			backingField.setAccessible(true);
 			R fieldValue = (R) backingField.get(pojo);
 
 			if (!Objects.equals(fieldValue, cachedValue)) {

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
@@ -35,6 +35,8 @@ public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
 	private ConfigBranch parent;
 
 	public BackedConfigLeaf(ConfigLeaf<S> backing, ConfigType<R, S, ?> type, Object pojo, Field backingField) {
+		if (!backingField.isAccessible()) throw new RuntimeFiberException("A BackedConfigLeaf may only be made for an accessible field!");
+
 		this.backing = backing;
 		this.type = type;
 		this.pojo = pojo;

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
@@ -121,7 +121,7 @@ public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
 			}
 		} catch (IllegalAccessException e) {
 			// Because this exception might appear to happen 'at random' to the user, we wrap it to at least provide more information about what just happened
-			(new RuntimeFiberException("Couldn't fetch setting value from POJO", e)).printStackTrace();
+			throw new RuntimeFiberException("Couldn't fetch setting value from POJO", e);
 		}
 
 		return backing.getValue();

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/fiber/annotation/BackedConfigLeaf.java
@@ -1,0 +1,161 @@
+package io.github.fablabsmc.fablabs.impl.fiber.annotation;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.github.fablabsmc.fablabs.api.fiber.v1.FiberId;
+import io.github.fablabsmc.fablabs.api.fiber.v1.exception.IllegalTreeStateException;
+import io.github.fablabsmc.fablabs.api.fiber.v1.exception.RuntimeFiberException;
+import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.SerializableType;
+import io.github.fablabsmc.fablabs.api.fiber.v1.schema.type.derived.ConfigType;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigAttribute;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigBranch;
+import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigLeaf;
+
+/**
+ * A config leaf backed by a field, {@linkplain ConfigType}, and deferred leaf.
+ *
+ * <p>It is used to fetch the backing field's values on each {@link #getValue()} call, to make sure a leaf and its corresponding POJO field are always synchronised.
+ *
+ * @param <R>
+ * @param <S>
+ */
+public class BackedConfigLeaf<R, S> implements ConfigLeaf<S> {
+	final ConfigLeaf<S> backing;
+	final ConfigType<R, S, ?> type;
+	final Object pojo;
+	final Field backingField;
+	private R cachedValue = null;
+	private ConfigBranch parent;
+
+	public BackedConfigLeaf(ConfigLeaf<S> backing, ConfigType<R, S, ?> type, Object pojo, Field backingField) {
+		this.backing = backing;
+		this.type = type;
+		this.pojo = pojo;
+		this.backingField = backingField;
+	}
+
+	@Override
+	public String getName() {
+		return backing.getName();
+	}
+
+	@Override
+	public Map<FiberId, ConfigAttribute<?>> getAttributes() {
+		return backing.getAttributes();
+	}
+
+	@Override
+	public <R, A> Optional<R> getAttributeValue(FiberId id, ConfigType<R, A, ?> type) {
+		return backing.getAttributeValue(id, type);
+	}
+
+	@Override
+	public <A> Optional<A> getAttributeValue(FiberId id, SerializableType<A> expectedType) {
+		return backing.getAttributeValue(id, expectedType);
+	}
+
+	@Override
+	public <A> ConfigAttribute<A> getOrCreateAttribute(FiberId id, SerializableType<A> attributeType, @Nullable A defaultValue) {
+		return backing.getOrCreateAttribute(id, attributeType, defaultValue);
+	}
+
+	@Nullable
+	@Override
+	public ConfigBranch getParent() {
+		return parent;
+	}
+
+	@Override
+	public void attachTo(ConfigBranch parent) throws IllegalTreeStateException {
+		// Attaching/detaching requires careful inspection of whether or not the parent's items contains `this`.
+		// In the case of deferred leaves, the leaf in the parent's items is the deferred leaf and not the backing leaf.
+		// Thus, we can't defer attaching/detaching to the backing leaf, as it will think it's not part of the parent's items.
+		if (this.parent != null && this.parent != parent) {
+			throw new IllegalTreeStateException(this + " needs to be detached before changing the parent");
+		}
+
+		// this node may have already been added by the collection
+		if (parent != null && !parent.getItems().contains(this)) {
+			parent.getItems().add(this);
+		}
+
+		this.parent = parent;
+	}
+
+	@Override
+	public void detach() {
+		// Note: infinite recursion between ConfigNode#detach() and NodeCollection#remove() could occur here,
+		// but the latter performs the actual collection removal before detaching
+		if (this.parent != null) {
+			// here, we also need to avoid triggering a ConcurrentModificationException
+			// thankfully, remove does not cause a CME if it's a no-op
+			this.parent.getItems().remove(this);
+		}
+
+		this.parent = null;
+	}
+
+	@Override
+	public boolean setValue(@Nonnull S value) {
+		return backing.setValue(value);
+	}
+
+	@Nonnull
+	@Override
+	@SuppressWarnings("unchecked")
+	public S getValue() {
+		try {
+			backingField.setAccessible(true);
+			R fieldValue = (R) backingField.get(pojo);
+
+			if (!Objects.equals(fieldValue, cachedValue)) {
+				this.setValue(type.toSerializedType(fieldValue));
+				cachedValue = fieldValue;
+			}
+		} catch (IllegalAccessException e) {
+			// Because this exception might appear to happen 'at random' to the user, we wrap it to at least provide more information about what just happened
+			(new RuntimeFiberException("Couldn't fetch setting value from POJO", e)).printStackTrace();
+		}
+
+		return backing.getValue();
+	}
+
+	@Override
+	public SerializableType<S> getConfigType() {
+		return backing.getConfigType();
+	}
+
+	@Nonnull
+	@Override
+	public BiConsumer<S, S> getListener() {
+		return backing.getListener();
+	}
+
+	@Override
+	public void addChangeListener(BiConsumer<S, S> listener) {
+		backing.addChangeListener(listener);
+	}
+
+	@Nullable
+	@Override
+	public S getDefaultValue() {
+		return backing.getDefaultValue();
+	}
+
+	@Override
+	public String getComment() {
+		return backing.getComment();
+	}
+
+	@Override
+	public boolean accepts(@Nonnull S rawValue) {
+		return backing.accepts(rawValue);
+	}
+}

--- a/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/io/github/fablabsmc/fablabs/api/fiber/v1/annotation/AnnotatedSettingsTest.java
@@ -281,6 +281,16 @@ class AnnotatedSettingsTest {
 		assertEquals(2, this.node.getItems().size(), "Node has two items");
 	}
 
+	@Test
+	@DisplayName("Directly mutated POJO")
+	void lateChangePojo() throws FiberException {
+		LateChangePojo pojo = new LateChangePojo();
+		this.annotatedSettings.applyToNode(this.node, pojo);
+		ConfigLeaf<BigDecimal> a = this.node.lookupLeaf("a", ConfigTypes.INTEGER.getSerializedType());
+		pojo.a = 10;
+		assertEquals(10, a.getValue().intValue());
+	}
+
 	private static class FinalSettingPojo {
 		private final int a = 5;
 	}
@@ -421,5 +431,9 @@ class AnnotatedSettingsTest {
 
 	private static class ExtendingPojo extends SuperPojo {
 		private int b = 5;
+	}
+
+	private static class LateChangePojo {
+		private int a = 5;
 	}
 }


### PR DESCRIPTION
Closes #16 

I apologise in advance for the atrocious design choices in this PR.

The annotation system currently nicely wraps around only the builder **API**: it uses no fiber internals. I wanted to maintain this while also being able to introduce an extra check in `getValue` (checking the corresponding field's value).

One way of achieving this would be to just introduce more methods to the builder to allow this kind of customisation (e.g. a method to change the type of leaf being built, so people can allow the builder to produce something else than a `ConfigLeafImpl`). This kind of approach seems rather hacky and would reduce the amount of guarantees fiber has when it comes to what type of nodes we're dealing with.

The approach I chose is to not modify API, but instead:
* Build a leaf the way we did before
* Remove it from its parent after building
* Add a new leaf that defers to the built leaf, but is also backed by the field we're currently building a leaf for. This way we can introduce that extra bit of `getValue` code we needed earlier.

This also means we can:
* [x] Remove the hacky listeners `AnnotatedSettingsImpl` adds, and implement them in `BackedConfigLeaf` instead.