### PR TITLE
Set modmenu api flag

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,5 +13,8 @@
   },
   "license": "Apache License 2.0",
   "icon": "assets/fiber_logo.png",
-  "environment": "*"
+  "environment": "*",
+  "custom": {
+    "modmenu:api": true
+  }
 }


### PR DESCRIPTION
This tells Mod Menu that this mod is a library. Mod Menu has a button to hide libraries and gives them a label.